### PR TITLE
Add support for imu/gps message streaming

### DIFF
--- a/Microstrain/microstrain.py
+++ b/Microstrain/microstrain.py
@@ -1,10 +1,10 @@
 r"""Library for LORD Microstrain 3DM-GX4-45 navigation unit.
 
-This library provides a software interface built around the MIP interface of the
+This library provides a software interface built around the MIP protocol of the
 device. It has not been tested against the current generation of devices, but
 would likely work since the structure is the mostly the same.
 
-This serial library communicates using the MIP packet format, which consits of
+This serial library communicates using the MIP packet format, which consists of
 header, payload, and checksum. The header defines which type of interaction is
 happening - either general commands, IMU, GPS, or EKF data. The payload is
 divided into fields, that also contain a descriptor to explain what kind of data
@@ -18,24 +18,66 @@ Helper dataclasses are introduced:
     the data.
   ReplyFormats: provide a mapping between packets and the data to make it easier
     to decode.
+
+The device shows up under ttyACM*, so the following udev rule is suggested to
+be added to 88-utilis.rules to make a specific device name on linux (without
+the line break):
+ACTION=="add", ATTRS{idVendor}=="0483", ATTRS{idProduct}=="5740", 
+  ATTRS{product}=="Lord Inertial Sensor", MODE="0660", SYMLINK+="ustrain"
+
+Usage example:
+unit = Microstrain3DM()
+# Collect scaled accelerometer data at 250 Hz (500 Hz max).
+unit.set_msg_fmt(Datamessages.IMU, descriptors=[0x04], rate_hz=[250.])
+data = unit.collect_data_stream(10.)  # Start streaming data for 10 seconds.
+
+# The data can be processed locally, or written out to csv with:
+unit.write_stream_data()
 """
+import enum
 import collections
 from dataclasses import dataclass
 import itertools
 import serial
 import struct
 import time
-from typing import Optional
+from typing import Any, Optional
+import os
 
-# The sync headers are always the same.
+# The sync headers are always the same, and indicate the start of a packet.
 SYNC1 = 0x75
 SYNC2 = 0x65
 SYNC_MSG = bytearray([SYNC1, SYNC2])
 
+class MessageFormatSelectors(enum.Enum):
+    """These are the possible options when setting up a data message format."""
+    NEW = 1
+    READ_BACK = 2
+    SAVE = 3
+    LOAD = 4
+    RESET = 5
+
+class DataMessages(enum.Enum):
+    """Small class to bundle interactions with the different message formats.
+    
+    Attributes:
+      msg_ind: the packet descriptor for a message of that type.
+      fmt_cmd: the field descriptor portion of the format command.
+      poll_cmd: the field desecriptor portion of the poll command.  
+    """
+    IMU = (0x80, 0x08, 0x01)
+    GPS = (0x81, 0x09, 0x02)
+    EKF = (0x82, 0x0a, 0x03)
+
+    def __init__(self, msg_ind, fmt_cmd, poll_cmd):
+        self.msg_ind = msg_ind
+        self.fmt_cmd = fmt_cmd
+        self.poll_cmd = poll_cmd
+
 def fletcher_checksum(packet: bytes) -> bytes:
     """Calculates fletcher checksum for bytes in packet."""
     check_sum = [sum(packet), sum(itertools.accumulate(packet))]
-    return bytearray([0xFF & check_sum[0], 0xFF & check_sum[1]])
+    return bytearray([0xff & check_sum[0], 0xff & check_sum[1]])
 
 @dataclass
 class MipsField:
@@ -43,7 +85,7 @@ class MipsField:
     
     For convenience, the data held in the MipsField is represented in both byte
     and as a list of integers. This gives some flexibility in how it is used in
-    the code.
+    the code, and makes it easier to reference the documentation.
 
     Attributes:
       field_len: the length of the field in bytes.
@@ -61,8 +103,9 @@ class MipsField:
                  data_bytes: Optional[bytes] = None):
         self.field_len = field_len
         self.field_desc = field_desc
+        # Ensure we load the data from one source, and make sure the alternate
+        # form is consistent.
         if data is not None:
-            # Make sure it's a bit array for consistency with read messages.
             self.data = list(data)
             self.data_bytes = bytearray(data)
         elif data_bytes is not None:
@@ -75,10 +118,11 @@ class MipsField:
     def __len__(self):
         """Returns length of field data."""
         data_len = len(self.data) if self.data else 0
+        # Additional 2 for field length and descriptor byte.
         return 2 + data_len
     
     def __iter__(self):
-        """Returns the contents of class."""
+        """Returns the contents of class (used for unpacking)."""
         content = [self.field_len, self.field_desc]
         if self.data:
             content += self.data
@@ -103,9 +147,12 @@ class MipsPacket:
         being sent to the device.
       payload: a list of MipsField objects, which contain the data to send or
         what was received from the device.
+      recv_time: a field that can be used to store time a streamed packet
+        arrived, used for decoding and writing out messages.
     """
     desc_set: int
     payload: list[MipsField]
+    recv_time: Optional[float] = None
 
     def __init__(self, desc_set: int, payload: list[MipsField]):
         self.desc_set = desc_set
@@ -114,7 +161,7 @@ class MipsPacket:
 
     @property
     def as_bytes(self) -> bytes:
-        """Returns the full packet info as bytes."""
+        """Returns the full packet info as bytes (used to send to device)."""
         field_bytes = []
         for entry in self.payload:
             field_bytes.extend(entry)
@@ -122,9 +169,34 @@ class MipsPacket:
                            + field_bytes)
         packet += fletcher_checksum(packet)
         return packet
+    
+    def convert_payload(self) -> list[collections.namedtuple]:
+        """Converts payload fields to their respective objects."""
+        entries = []
+        for f in self.payload:
+            value = ReplyFormats.process_field(self.desc_set, f)
+            entries.append(value)
+        return entries
+    
+    def flatten_payload(self) -> list[Any]:
+        """Flattens values in payload fields into a list."""
+        processed_fields = self.convert_payload()
+        return list(itertools.chain(*processed_fields))
+
 
 class ReplyFormats:
-    """Container of messages and mapping to formats for unpacking."""
+    """Container of messages and mapping to formats for unpacking.
+    
+    This class contains a number of helper classes introduced to make it more
+    obvious what's in the data received from the device. It maps the format
+    to the struct unpacking instructions, as well as additional helpful info
+    like the units or info of the terms.
+
+    This class is intended to operate on individual fields, and contains
+    class methods to:
+        - Unpack a field's byte data into an object
+        - Retrieve units for the field
+    """
     # The ACK/NACK message consists of a command echo and error code.
     # This comes back when the field description is 0xf1.
     Ack = collections.namedtuple('Ack', ['cmd_echo', 'error_code'])
@@ -134,28 +206,190 @@ class ReplyFormats:
     DevInfo = collections.namedtuple('DevInfo',[
         'fw_ver', 'model_name', 'model_number', 'serial_num', 'lot_num',
         'dev_opts'])
+    
+    DataFmt = collections.namedtuple('DataFmt',
+                                     ['descriptor', 'rate_decimation'])
 
-    byte_formats = {
-        0x81: ('<H16s16s16s16s16s', DevInfo),
-        0x83: ('<I', int),
-        0xf1: ('<BB', Ack),
+    # Each set of information stores the format, class, and units of the data.
+    base_set = {
+        0x81: ('>H16s16s16s16s16s', DevInfo),  # Device info.
+        0x83: ('>I', int),  # Built-in self test.
+        0xf1: ('>BB', Ack),  # (N)Ack message.
+    }
+
+    Vector = collections.namedtuple('Vector', ['x', 'y', 'z'])
+    Quat = collections.namedtuple('Quat', ['q0', 'q1', 'q2', 'q3'])
+    Euler = collections.namedtuple('Euler', ['roll', 'pitch', 'yaw'])
+    Matrix = collections.namedtuple('Matrix', ['M11', 'M12', 'M13',
+                                               'M21', 'M22', 'M23',
+                                               'M31', 'M32', 'M33'])
+    Timestamp = collections.namedtuple('GpsTimestamp',
+                                       ['time_of_week', 'week_num', 'flags'])
+    AmbPressure = collections.namedtuple('AmbPressure', ['pressure'])
+
+    imu_set = {
+        0x04: ('>fff', Vector),  # Accelerometer vector.
+        0x05: ('>fff', Vector),  # Gyro vector.
+        0x06: ('>fff', Vector),  # Magnetometer vector.
+        0x07: ('>fff', Vector),  # Delta theta vector.
+        0x08: ('>fff', Vector),  # Delta velocity vector.
+        0x09: ('>fffffffff', Matrix),  # CF orientation matrix.
+        0x0a: ('>ffff', Quat),  # Complimentary filter (CF) quaternion.
+        0x0c: ('>fff', Euler),  # CF Euler Angles.
+        0x10: ('>fff', Vector),  # CF stabilized mag vector.
+        0x11: ('>fff', Vector),  # CF stabilized accel vector.
+        0x12: ('>dHH', Timestamp),  # GPS correlation timestamp.
+        0x17: ('>f', AmbPressure),  # Scaled ambient pressure.
+    }
+
+    imu_units = {
+        0x04: 3*['Accel g'],
+        0x05: 3*['Gyro rad/s'],
+        0x06: 3*['Mag gauss'],
+        0x07: 3*['Delta Theta rad'],
+        0x08: 3*['Delta Vel g*s'],
+        0x09: 9*['n/a'],
+        0x0a: ['q0', 'q1', 'q2', 'q3'],
+        0x0c: 3*['rad'],
+        0x10: 3*['CF Mag gauss'],
+        0x11: 3*['CF Accel g'],
+        0x12: ['sec', 'week', 'n/a'],
+        0x17: ['milliBar'],     
+    }
+
+    PosLLH = collections.namedtuple(
+        'PosLLH',['lat', 'lon', 'ellipsoid_ht', 'msl_ht',
+                  'horizontal_acc', 'vertical_acc', 'flags'
+    ])
+    PosECEF = collections.namedtuple(
+        'PosECEF', ['x', 'y', 'z', 'position_acc', 'flags'])
+    VelNED = collections.namedtuple('VelNED', [
+        'north', 'east', 'down', 'speed', 'ground_speed', 'heading',
+        'speed_acc', 'heading_acc', 'flags'
+    ])
+    VelECEF = collections.namedtuple('VelECEF',[
+        'x', 'y', 'z', 'velocity_acc', 'flags'
+    ])
+    Dilution = collections.namedtuple('Dilution', [
+        'geometric_dop', 'position_dop', 'horizontal_dop', 'vertical_dop',
+        'time_dop', 'northing_dop', 'easting_dop', 'flags'
+    ])
+    UTC = collections.namedtuple('UTC', [
+        'year', 'month', 'day', 'hour', 'minute', 'second', 'msec', 'flags'
+    ])
+    GPSTime = collections.namedtuple('GPSTime', [
+        'tow', 'week_num', 'flags'
+    ])
+    ClockInfo = collections.namedtuple('ClockInfo', [
+        'clock_bias', 'clock_drift', 'acc_est', 'flags'
+    ])
+    GPSFix = collections.namedtuple('GPSFix', [
+        'fix_type', 'num_sol_SVs', 'fix_flags', 'valid_flags'
+    ])
+    SvInfo = collections.namedtuple('SvInfo', [
+        'channel', 'sv_id', 'carrier_noise_ratio', 'az', 'el', 'sv_flags',
+        'valid_flags'
+    ])
+    GpsHwStatus = collections.namedtuple('GpsHwStatus', [
+        'sensor_state', 'antenna_state', 'antenna_power', 'flags'
+    ])
+
+    gps_set = {
+        0x03: ('>ddddffH', PosLLH),
+        0x04: ('>dddfH', PosECEF),
+        0x05: ('>ffffffffH', VelNED),
+        0x06: ('>ffffH', VelECEF),
+        0x07: ('>fffffffH', Dilution),
+        0x08: ('>HBBBBBIH', UTC),
+        0x09: ('>dHH', GPSTime),
+        0x0a: ('>dddH', ClockInfo),
+        0x0b: ('>BBHH', GPSFix),
+        0x0c: ('>BBH2s2sHH', SvInfo),
+        0x0d: ('>BBBH', GpsHwStatus)
+    }
+
+    gps_units = {
+        0x03: ['deg', 'deg', 'm', 'm', 'm', 'm', 'n/a'],
+        0x04: 4*['m'] + ['n/a'],
+        0x05: 5*['m/s'] + ['deg', 'm/s', 'deg', 'n/a'],
+        0x06: 4*['m/s'] + ['n/a'],
+        0x07: 8*['n/a'],
+        0x08: ['years', 'months', 'days', 'hrs', 'min', 'sec', 'ms', 'n/a'],
+        0x09: ['sec', 'week', 'n/a'],
+        0x0a: ['sec', 'sec/sec', 'sec', 'n/a'],
+        0x0b: ['n/a', 'count'] + 2*['n/a'],
+        0x0c: ['chan_num', 'sv_id_num', 'dBHz', 'deg', 'deg'] + 2*['n/a'],
+        0x0d: 4*['n/a']    
+    }
+
+    format_map = {
+        0x01: base_set,
+        0x0c: base_set,
+        DataMessages.IMU.msg_ind: imu_set,
+        DataMessages.GPS.msg_ind: gps_set,
     }
 
     @classmethod
-    def process_field(self, mips_field: MipsField) -> tuple[any,...]:
+    def process_field(self, desc_set: int,
+                      mips_field: MipsField) -> tuple[any,...]:
         """Returns processed bytes according to field description."""
-        fmt, obj = self.byte_formats[mips_field.field_desc]
+        message_set = self.format_map[desc_set]
+        fmt, obj = message_set[mips_field.field_desc]
         return obj(*struct.unpack(fmt, mips_field.data_bytes)) 
+    
+    @classmethod
+    def get_field_units(
+        self, desc_set: int, mips_field: MipsField) -> list[str]:
+        """Returns units for MipsField provided."""
+        if desc_set == DataMessages.IMU.msg_ind:
+            units = self.imu_units
+        elif desc_set == DataMessages.GPS.msg_ind:
+            units = self.gps_units
+        return units[mips_field.field_desc]
+
+
+def process_mips_packets(
+        packets: list[MipsPacket]) -> list[collections.namedtuple]:
+    """Converts fields of MipsPackets to objects."""
+    return list(itertools.chain.from_iterable(
+        [p.convert_payload() for p in packets]))
+
+
+def divide_mips_packets(
+        packets: list[MipsPacket]) -> tuple[MipsPacket, MipsPacket, MipsPacket]:
+    """Separates MipsPackets into IMU, GPS, and EKF formats."""
+    imu_data = []
+    gps_data = []
+    ekf_data = []
+    for p in packets:
+        if p.desc_set == DataMessages.IMU.msg_ind:
+            imu_data.append(p)
+        elif p.desc_set == DataMessages.GPS.msg_ind:
+            gps_data.append(p)
+        elif p.desc_set == DataMessages.EKF.msg_ind:
+            ekf_data.append(p)
+    return imu_data, gps_data, ekf_data 
 
 
 class Microstrain3DM:
     """An interface for Microstrain 3D motion devices."""
+
+    # Base rates for decimation of data from unit, specific to GX4 model.
+    IMU_RATE = 500.0
+    EKF_RATE = 500.0
+    GPS_RATE = 4.0
     
     def __init__(self, port: str ='COM5', baudrate: int = 115200):
         self._ser = serial.Serial(port=port, baudrate=baudrate)
         # These are for debugging the raw traffic.
         self._read_buffer = collections.deque(maxlen=10)
         self._write_buffer = collections.deque(maxlen=10)
+        # Dictionaries to map data collection frequencies to data messages.
+        self._imu_fmt = None
+        self._gps_fmt = None
+        self._ekf_fmt = None
+        # This is storage for data collected during streaming.
+        self._stream_results = None  # Packets received.
 
     def _split_payload_to_fields(self, payload: bytes) -> list[MipsField]:
         """Takes payload bytes and divides them into fields."""
@@ -171,7 +405,7 @@ class Microstrain3DM:
         return field_data
     
     def _read_one_packet(self) -> MipsPacket:
-        """Returns the first MIP packet found on the serial connection."""
+        """Returns the first MipsPacket found on the serial connection."""
         self._ser.read_until(SYNC_MSG)
         desc_set = self._ser.read(1)
         payload_len = self._ser.read(1)
@@ -197,11 +431,7 @@ class Microstrain3DM:
                               ) -> list[collections.namedtuple]:
         """Sends command and returns device reply object."""
         response = self._send_command(packet)
-        print(f'Received: {response}')
-        parsed_fields = []
-        for field in response.payload:
-            parsed_fields.append(ReplyFormats.process_field(field))
-        return parsed_fields
+        return process_mips_packets([response])
 
     def dump_read_buffer(self) -> collections.deque:
         return self._read_buffer
@@ -260,3 +490,208 @@ class Microstrain3DM:
         data = self._send_and_parse_reply(
             MipsPacket(0x01,[MipsField(0x02, 0x05)]))
         return data[1]
+    
+    def _generate_field_for_descriptors(
+            self, cmd_desc: int, base_rate: float, selector: int,
+            descriptors: list[int], rate_hz: list[float]) -> MipsField:
+        """Prepares descriptors to send in message format command."""
+        num_descriptors = len(descriptors)
+        field_data = [selector, num_descriptors]
+        for i in range(num_descriptors):
+            # Each field contains the descriptor number, and the decimation
+            # factor as 2 bytes.
+            desc_rate = max(int(base_rate / rate_hz[i]), 1)
+            field_data.extend([descriptors[i],
+                               desc_rate >> 8, desc_rate & 0xff])
+        return MipsField(4 + 3 * num_descriptors, cmd_desc, field_data)
+    
+    def _get_max_rate(self, msg_type: DataMessages) -> float:
+        if msg_type == DataMessages.IMU:
+            base_rate = self.IMU_RATE
+        elif msg_type == DataMessages.GPS:
+            base_rate = self.GPS_RATE
+        else:
+            base_rate = self.EKF_RATE
+        return base_rate
+    
+    def set_msg_fmt(
+            self,
+            msg_type: DataMessages = DataMessages.IMU,
+            descriptors: list[int] = [0x04],
+            rate_hz: list[float] = [500.]) -> MipsField:
+        """Sets data format for device msg_type specified.
+        
+        All data formats are configured with this command. The device can be
+        configured to stream data, and the command can define under what
+        conditions the settings will be in effect (i.e. at startup).
+
+        Args:
+          msg_type: which data message the format is configured for.
+          descriptors: A list of the codes for which measurements to send, see
+            ResponseFormats for details.
+          rate_hz: the rate to collect the data at to calculate the decimation.
+            Can either be one number, or a list of rates, one per descriptor.
+        Returns:
+          The MipsField ACK response from device.
+        """
+        num_descriptors = len(descriptors)
+        desc_hz = (rate_hz if num_descriptors == len(rate_hz)
+            else num_descriptors * list(rate_hz))
+        self._add_descriptors_and_rates(msg_type, descriptors, desc_hz)
+        fmt_payload = self._generate_field_for_descriptors(
+            msg_type.fmt_cmd, self._get_max_rate(msg_type),
+            MessageFormatSelectors.NEW.value, descriptors, desc_hz)
+        data = self._send_and_parse_reply(MipsPacket(0x0c, [fmt_payload]))
+        return data[0]
+    
+    def _add_descriptors_and_rates(self, msg_type: DataMessages,
+                                   descriptors: list[int],
+                                   desc_hz: list[float]):
+        """Stores descriptors for message type to help divide data later.
+        
+        Note: this will overwrite previous values.
+        """
+        keys = set(desc_hz)
+        update_dict = {}       
+        for k in keys:
+            desc_for_rate = [d for d, r in zip(descriptors, desc_hz) if r == k]
+            update_dict[k] = desc_for_rate
+        if msg_type == DataMessages.IMU:
+            self._imu_fmt = update_dict
+        elif msg_type == DataMessages.GPS:
+            self._gps_fmt = update_dict
+        else:
+            self._ekf_fmt = update_dict
+    
+    def get_msg_fmt(self,
+                       msg_type: DataMessages = DataMessages.IMU) -> MipsField:
+        """Returns the message format and decimation factors requested."""
+        cmd = MipsField(0x04, msg_type.fmt_cmd,
+                        [MessageFormatSelectors.READ_BACK.value, 0x00])
+        data = self._send_command(MipsPacket(0x0c, [cmd]))
+        # The format will be returned in a field after the ack message, and
+        # consist of repeated messages.
+        formats = data.payload[1]
+        # The number of descriptors is stored in location 0, then the repeated
+        # format begins.
+        return [ReplyFormats.DataFmt(*t) for t in
+                struct.iter_unpack('>BH', formats.data_bytes[1:])]
+    
+    def save_msg_fmt(self,
+                        msg_type: DataMessages = DataMessages.IMU) -> MipsField:
+        """Saves the current settings to apply at startup."""
+        cmd = MipsField(0x04, msg_type.fmt_cmd,
+                        [MessageFormatSelectors.SAVE.value, 0x00])
+        data = self._send_command(MipsPacket(0x0c, [cmd]))
+        return data.convert_payload()
+    
+    def load_msg_fmt(
+            self, msg_type: DataMessages = DataMessages.IMU) -> MipsField:
+        """Reloads saved settings onto device."""
+        cmd = MipsField(0x04, msg_type.fmt_cmd,
+                        [MessageFormatSelectors.LOAD.value, 0x00])
+        data = self._send_command(MipsPacket(0x0c, [cmd]))
+        return data.convert_payload()
+    
+    def reset_msg_fmt(
+            self, msg_type: DataMessages = DataMessages.IMU) -> MipsField:
+        """Resets the message format to factory defaults."""
+        cmd = MipsField(0x04, msg_type.fmt_cmd,
+                        [MessageFormatSelectors.RESET.value, 0x00])
+        data = self._send_command(MipsPacket(0x0c, [cmd]))
+        # Clear the stored version of the format.
+        self._imu_fmt = None
+        self._gps_fmt = None
+        self._ekf_fmt = None
+        return data.convert_payload()
+    
+    def poll_data(
+            self, msg_type: DataMessages = DataMessages.IMU) -> MipsField:
+        """Gets a set of values from device data type in current format."""
+        # The poll request suppresses the normal (n)ack reply with option = 1.
+        data = self._send_and_parse_reply(
+            MipsPacket(0x0c,
+                       [MipsField(0x04, msg_type.poll_cmd, [0x01, 0x00])]))
+        return data
+
+    def collect_data_stream(
+            self,
+            duration_sec: float = 10.) -> tuple[list[float], list[MipsPacket]]:
+        """Collects packets for a time and returns data split to fields.
+        
+        Prior to calling this, you must have put a format onto the device. This
+        function will handle starting and stopping the data streaming.
+
+        Args:
+          duration_sec: the amount of time to collect data for.
+        Returns:
+          The list of objects read from device.
+        """
+        self.device_resume()
+        t_end = time.time() + duration_sec
+        payload_recv = []
+        while (t_now := time.time()) < t_end:
+            # Read all packets available.
+            while self._ser.in_waiting:
+                new_packet = self._read_one_packet()
+                new_packet.recv_time = t_now
+                payload_recv.append(new_packet)
+            time.sleep(0.001)
+        self.device_idle()
+        self._stream_results = payload_recv
+        
+        return payload_recv
+    
+    def _create_file_header_for_fmt(
+            self,
+            msg_type: DataMessages,
+            desc_fmt: dict[float, list[int]]) -> dict[float, str]:
+        """Makes a string useable for file header for received data."""
+        name = msg_type.name.lower()
+        headers = {}
+        for rate, descriptors in desc_fmt.items():
+            data_map = getattr(ReplyFormats, name + '_set')
+            data_units = getattr(ReplyFormats, name + '_units')
+            # Create header for file.
+            hdr_line = []
+            for d in descriptors:
+                # Look up the data type and units.
+                object = data_map[d][1]
+                units = data_units[d]
+                # Join for column name.
+                hdr = [f'{v} ({u})' for v, u in zip(object._fields, units)]
+                hdr_line.extend(hdr)
+            headers[rate] = hdr_line
+        return headers
+    
+    def write_stream_data(self, folder: str = './'):
+        """Writes stream data to files."""
+        # Divide packets by data message type, keep time.
+        processed_data = divide_mips_packets(self._stream_results)
+        message_types = (DataMessages.IMU, DataMessages.GPS, DataMessages.EKF)
+        messages = (self._imu_fmt, self._gps_fmt, self._ekf_fmt)
+
+        # For each data message collection, pick ones at same rate.
+        for i in range(3):
+            msg, fmt, data = message_types[i], messages[i], processed_data[i]
+            if fmt is None:
+                continue
+            headers = self._create_file_header_for_fmt(msg, fmt)
+            for rate, descriptors in fmt.items():
+                fname = f'stream_{msg.name.lower()}_{rate}_hz.txt'
+                entries = [['time (s)'] + headers[rate]]
+                for d in data:
+                    t = str(d.recv_time)
+                    for f, val in zip(d.payload, d.convert_payload()):
+                        # For each payload field, check if it is at this rate.
+                        if f.field_desc in descriptors:
+                            # Store time once per entry, this keeps messages
+                            # at a lower rate from getting the faster time
+                            # interval of another measurement.
+                            if t not in entries[-1]:
+                                entries.append([t])
+                            entries[-1].extend(val)
+                # Write to file.
+                with open(os.path.join(folder, fname), 'w') as dest:
+                    for entry in entries:
+                        dest.write(','.join(map(str, entry)) + '\n')

--- a/Microstrain/microstrain_test.py
+++ b/Microstrain/microstrain_test.py
@@ -21,6 +21,21 @@ def test_mips_field_as_iter():
     assert list(sample) == [0x06, 0x11, 0x02, 0x04, 0x06, 0x08]
 
 @pytest.mark.parametrize(
+    'msg_type, field_len, field_desc, data_bytes, expect', [
+        (microstrain.DataMessages.IMU.msg_ind, 0x0e, 0x04,
+         b'\x3e\x7a\x63\xa0xbb\x8e\x3b\x29\x7f\xe5\xbf7f',
+         ['Accel g', 'Accel g', 'Accel g']),
+        (microstrain.DataMessages.GPS.msg_ind, 0x08, 0x0b,
+         b'\x00\x01\x00\x02\x00\x03', ['n/a', 'count', 'n/a', 'n/a'])]
+)
+def test_get_units_for_data_message(msg_type, field_len, field_desc, data_bytes,
+                                    expect):
+    field_data = microstrain.MipsField(field_len, field_desc,
+                                       data_bytes=data_bytes)
+    units = microstrain.ReplyFormats.get_field_units(msg_type, field_data)
+    assert units == expect
+
+@pytest.mark.parametrize(
     'payload_bytes, field_list', [
         # Device reset example - single field case.
         (b'\x04\xf1\x7e\x00', [
@@ -55,6 +70,50 @@ def test_checksum_calculation(packet, expected_checksum):
     check_sum = microstrain.fletcher_checksum(packet)
     assert check_sum == expected_checksum
 
+def test_process_mips_packet():
+    imu_fields = [
+        microstrain.MipsField(
+        0x0e, 0x04, data_bytes=b'?\x80\x00\x00@\x00\x00\x00@@\x00\x00'),
+        microstrain.MipsField(0x06, 0x17, data_bytes=b'?\x80\x00\x00'),
+        microstrain.MipsField(
+        0x12, 0x0a, data_bytes=b'?\x80\x00\x00' + 12*b'\x00')]
+    gps_fields = [microstrain.MipsField(0x08, 0x0b, data = [0, 1, 0, 2, 0, 3])]
+    imu_desc = microstrain.DataMessages.IMU.msg_ind
+    gps_desc = microstrain.DataMessages.GPS.msg_ind
+    packets = [microstrain.MipsPacket(imu_desc, imu_fields),
+               microstrain.MipsPacket(gps_desc, gps_fields)]
+    result = microstrain.process_mips_packets(packets)
+    assert result == [microstrain.ReplyFormats.Vector(1.0, 2.0, 3.0),
+                      microstrain.ReplyFormats.AmbPressure(1.0),
+                      microstrain.ReplyFormats.Quat(1.0, 0, 0, 0),
+                      microstrain.ReplyFormats.GPSFix(0, 1, 2, 3)]
+    
+def test_flatten_payload():
+    gps_fields = [
+        microstrain.MipsField(0x08, 0x0b, data = [0, 1, 0, 2, 0, 3]),
+        microstrain.MipsField(0x0f, 0x08,
+                              data=[0, 4, 5, 6, 7, 8, 9, 0, 0, 0, 10, 0, 11])]
+    gps_desc = microstrain.DataMessages.GPS.msg_ind
+    packet = microstrain.MipsPacket(gps_desc, gps_fields)
+    assert packet.flatten_payload() == [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]
+
+def test_divide_mips_packets():
+    imu_packet = microstrain.MipsPacket(
+        microstrain.DataMessages.IMU.msg_ind,
+        [microstrain.MipsField(0x06, 0x17, data_bytes=b'?\x80\x00\x00')])
+    gps_packet = microstrain.MipsPacket(
+        microstrain.DataMessages.GPS.msg_ind,
+        [microstrain.MipsField(0x08, 0x0b, data = [0, 1, 0, 2, 0, 3])]
+    )
+    ekf_packet = microstrain.MipsPacket(
+        microstrain.DataMessages.EKF.msg_ind,
+        [microstrain.MipsField(0x02, 0xff)]
+    )
+    packets = [imu_packet, gps_packet, ekf_packet, gps_packet, imu_packet,
+               imu_packet]
+    imu, gps, ekf = microstrain.divide_mips_packets(packets)
+    assert (len(imu), len(gps), len(ekf)) == (3, 2, 1)
+
 def test_read_one_packet():
     packet = b'\x01\x0a\x04\xf1\x05\x00\x06\x83\x01\x02\x03\x04\x68\x7d'
     unit = microstrain.Microstrain3DM()
@@ -74,7 +133,7 @@ def test_ping_command(mocker):
     # works.
     mock_read = mocker.patch('microstrain.Microstrain3DM._read_one_packet')
     mock_read.return_value = microstrain.MipsPacket(
-        b'\x01', [microstrain.MipsField(0x04, 0xf1,
+        0x01, [microstrain.MipsField(0x04, 0xf1,
                                         data=[0x01, error_expected])])
     unit = microstrain.Microstrain3DM()
     response = unit.device_ping()  # Ack response received.
@@ -98,4 +157,109 @@ def test_device_command(mocker, command, expected_bytes):
     unit = microstrain.Microstrain3DM()
     getattr(unit, command)()
     send_packet = mock_send.call_args[0][0]
-    assert send_packet.as_bytes == expected_bytes   
+    assert send_packet.as_bytes == expected_bytes
+
+def test_set_imu_format(mocker):
+    mock_send = mocker.patch('microstrain.Microstrain3DM._send_and_parse_reply')
+    unit = microstrain.Microstrain3DM()
+    unit.set_msg_fmt(microstrain.DataMessages.IMU, [0x04, 0x05], [50.])
+    send_packet = mock_send.call_args[0][0]
+    expect = b'\x75\x65\x0c\x0a\x0a\x08\x01\x02\x04\x00\x0a\x05\x00\x0a\x22\xa0'
+    assert send_packet.as_bytes == expect
+
+def test_set_gps_format(mocker):
+    mock_send = mocker.patch('microstrain.Microstrain3DM._send_and_parse_reply')
+    unit = microstrain.Microstrain3DM()
+    unit.set_msg_fmt(microstrain.DataMessages.GPS, [0x03, 0x05], [1.])
+    send_packet = mock_send.call_args[0][0]
+    expect = b'\x75\x65\x0c\x0a\x0a\x09\x01\x02\x03\x00\x04\x05\x00\x04\x16\x85'
+    assert send_packet.as_bytes == expect
+
+def test_set_estimation_filter_format(mocker):
+    mock_send = mocker.patch('microstrain.Microstrain3DM._send_and_parse_reply')
+    unit = microstrain.Microstrain3DM()
+    unit.set_msg_fmt(microstrain.DataMessages.EKF, [0x01, 0x02], [500.])
+    send_packet = mock_send.call_args[0][0]
+    expect = b'\x75\x65\x0c\x0a\x0a\x0a\x01\x02\x01\x00\x01\x02\x00\x01\x0c\x6a'
+    assert send_packet.as_bytes == expect  
+
+def test_get_msg_format_for_gps(mocker):
+    mock_cmd = mocker.patch('microstrain.Microstrain3DM._send_command')
+    mock_cmd.return_value = microstrain.MipsPacket(0x0c,[
+        microstrain.MipsField(0x04, 0xf1, [0x09, 0x00]),
+        microstrain.MipsField(0x06, 0x81, [0x01, 0x03, 0x00, 0x04])
+    ])
+    unit = microstrain.Microstrain3DM()
+    formats = unit.get_msg_fmt(microstrain.DataMessages.GPS)
+    send_packet = mock_cmd.call_args[0][0]
+    expect = b'\x75\x65\x0c\x04\x04\x09\x02\x00\xf9\xf6'
+    assert send_packet.as_bytes == expect
+    assert formats == [microstrain.ReplyFormats.DataFmt(0x03, 0x04)]
+
+def test_save_msg_format_for_estimation_filter(mocker):
+    mock_cmd = mocker.patch('microstrain.Microstrain3DM._send_command')
+    unit = microstrain.Microstrain3DM()
+    unit.save_msg_fmt(microstrain.DataMessages.EKF)
+    send_packet = mock_cmd.call_args[0][0]
+    expect = b'\x75\x65\x0c\x04\x04\x0a\x03\x00\xfb\xfb'
+    assert send_packet.as_bytes == expect
+
+def test_load_msg_format_for_imu(mocker):
+    mock_cmd = mocker.patch('microstrain.Microstrain3DM._send_command')
+    unit = microstrain.Microstrain3DM()
+    unit.load_msg_fmt(microstrain.DataMessages.IMU)
+    send_packet = mock_cmd.call_args[0][0]
+    expect = b'\x75\x65\x0c\x04\x04\x08\x04\x00\xfa\xf7'
+    assert send_packet.as_bytes == expect
+
+def test_reset_msg_format_for_gps(mocker):
+    mock_cmd = mocker.patch('microstrain.Microstrain3DM._send_command')
+    unit = microstrain.Microstrain3DM()
+    unit.reset_msg_fmt(microstrain.DataMessages.GPS)
+    send_packet = mock_cmd.call_args[0][0]
+    expect = b'\x75\x65\x0c\x04\x04\x09\x05\x00\xfc\xfc'
+    assert send_packet.as_bytes == expect
+
+def test_poll_data_for_estimation_filter(mocker):
+    mock_send = mocker.patch('microstrain.Microstrain3DM._send_and_parse_reply')
+    unit = microstrain.Microstrain3DM()
+    unit.poll_data(microstrain.DataMessages.EKF)
+    send_packet = mock_send.call_args[0][0]
+    expect = b'\x75\x65\x0c\x04\x04\x03\x01\x00\xf2\xe2'
+    assert send_packet.as_bytes == expect
+
+def test_create_headers_for_file():
+    unit = microstrain.Microstrain3DM()
+    header = unit._create_file_header_for_fmt(
+        microstrain.DataMessages.IMU, {1.0: [0x04, 0x06], 2.0: [0x17]})
+    expect = {1.0: ['x (Accel g)', 'y (Accel g)', 'z (Accel g)',
+                    'x (Mag gauss)', 'y (Mag gauss)', 'z (Mag gauss)'],
+              2.0: ['pressure (milliBar)']}
+    assert header == expect
+
+def test_collect_data_stream(mocker):
+    mock_resume = mocker.patch('microstrain.Microstrain3DM.device_resume')
+    mock_idle = mocker.patch('microstrain.Microstrain3DM.device_idle')
+    mocker.patch('microstrain.Microstrain3DM._read_one_packet')
+    mock_time = mocker.patch('microstrain.time')
+    mock_time.time.side_effect = [0, 1, 2]
+    unit = microstrain.Microstrain3DM()
+    unit._ser.in_waiting = False
+    unit.collect_data_stream(2)
+    # Really want to ensure that the device is managed correctly.
+    mock_resume.assert_called_once()
+    mock_idle.assert_called_once()
+
+def test_write_stream_data(mocker):
+    mock_open = mocker.patch('builtins.open')
+    unit = microstrain.Microstrain3DM()
+    unit._stream_results = [
+        microstrain.MipsPacket(
+            microstrain.DataMessages.IMU.msg_ind,
+            [microstrain.MipsField(0x06, 0x17, data_bytes=b'?\x80\x00\x00')])]
+    unit._imu_fmt = {1.0: [0x17]}
+    unit.write_stream_data()
+    # Make sure import info in file name.
+    file_destination = mock_open.call_args[0][0]
+    assert all(['1.0' in file_destination, 'imu' in file_destination])
+    


### PR DESCRIPTION
This set of changes adds the ability to configure, collect, and convert data from the device. The current set of formats supported are imu and gps. Testing coverage included with updates to the unit tests and additional cases in the run binary.