### PR TITLE
Refactor microstrain library to be more maintainable

### DIFF
--- a/.github/workflows/microstrain-pytest.yml
+++ b/.github/workflows/microstrain-pytest.yml
@@ -5,7 +5,8 @@ name: Microstrain library
 
 env:
   LIBRARY_DIR: Microstrain
-  LIBRARY_NAME: microstrain
+  LIBRARY_MICRO: microstrain
+  LIBRARY_PACKETS: packets
 
 # Unfortunately, the variable from the environment is not available to use in the "on" portion.
 on:
@@ -47,7 +48,7 @@ jobs:
         flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
     - name: Test ${{env.LIBRARY_DIR}} with pytest
       run: |
-        pytest ${{env.LIBRARY_DIR}}/ --doctest-modules --junitxml=junit/test-results-${{ matrix.python-version }}.xml --cov=${{ env.LIBRARY_NAME }} --cov-report=html --disable-pytest-warnings
+        pytest ${{env.LIBRARY_DIR}}/ --doctest-modules --junitxml=junit/test-results-${{ matrix.python-version }}.xml --cov=${{ env.LIBRARY_MICRO }} --cov=${{ env.LIBRARY_PACKETS }} --cov-report=html --disable-pytest-warnings
     - name: Upload pytest test results
       uses: actions/upload-artifact@v3
       with:

--- a/Microstrain/microstrain.py
+++ b/Microstrain/microstrain.py
@@ -9,15 +9,7 @@ header, payload, and checksum. The header defines which type of interaction is
 happening - either general commands, IMU, GPS, or EKF data. The payload is
 divided into fields, that also contain a descriptor to explain what kind of data
 is included. The classes were designed to make it easy to translate between the
-documentation and code.
-
-Helper dataclasses are introduced:
-  MipsField: are strung together as a list and packed into the payload portion
-    of the packet.
-  MipsPacket: the top level container that describes the payload and holds all
-    the data.
-  ReplyFormats: provide a mapping between packets and the data to make it easier
-    to decode.
+documentation and code. See the packets library for more details.
 
 The device shows up under ttyACM*, so the following udev rule is suggested to
 be added to 88-utilis.rules to make a specific device name on linux (without
@@ -26,9 +18,10 @@ ACTION=="add", ATTRS{idVendor}=="0483", ATTRS{idProduct}=="5740",
   ATTRS{product}=="Lord Inertial Sensor", MODE="0660", SYMLINK+="ustrain"
 
 Usage example:
+from packets import DataMessages
 unit = Microstrain3DM()
 # Collect scaled accelerometer data at 250 Hz (500 Hz max).
-unit.set_msg_fmt(Datamessages.IMU, descriptors=[0x04], rate_hz=[250.])
+unit.set_msg_fmt(DataMessages.IMU, descriptors=[0x04], rate_hz=[250.])
 data = unit.collect_data_stream(10.)  # Start streaming data for 10 seconds.
 
 # The data can be processed locally, or written out to csv with:
@@ -37,17 +30,12 @@ unit.write_stream_data()
 import enum
 import collections
 from dataclasses import dataclass
-import itertools
+import packets
 import serial
 import struct
 import time
 from typing import Any, Optional
 import os
-
-# The sync headers are always the same, and indicate the start of a packet.
-SYNC1 = 0x75
-SYNC2 = 0x65
-SYNC_MSG = bytearray([SYNC1, SYNC2])
 
 class FunctionSelectors(enum.Enum):
     """These are the possible options when setting up a data message format."""
@@ -69,453 +57,6 @@ class EkfHeadingUpdate(enum.Enum):
     GPS = 2
     EXT = 3
 
-class DataMessages(enum.Enum):
-    """Small class to bundle interactions with the different message formats.
-    
-    Attributes:
-      msg_ind: the packet descriptor for a message of that type.
-      fmt_cmd: the field descriptor portion of the format command.
-      poll_cmd: the field desecriptor portion of the poll command.  
-    """
-    IMU = (0x80, 0x08, 0x01, 0x06)
-    GPS = (0x81, 0x09, 0x02, 0x07)
-    EKF = (0x82, 0x0a, 0x03, 0x0b)
-
-    def __init__(self, msg_ind, fmt_cmd, poll_cmd, rate_cmd):
-        self.msg_ind = msg_ind
-        self.fmt_cmd = fmt_cmd
-        self.poll_cmd = poll_cmd
-        self.rate_cmd = rate_cmd
-
-
-def fletcher_checksum(packet: bytes) -> bytes:
-    """Calculates fletcher checksum for bytes in packet."""
-    check_sum = [sum(packet), sum(itertools.accumulate(packet))]
-    return bytearray([0xff & check_sum[0], 0xff & check_sum[1]])
-
-@dataclass
-class MipsField:
-    """Container that represents the payload data in the MipsPacket.
-    
-    For convenience, the data held in the MipsField is represented in both byte
-    and as a list of integers. This gives some flexibility in how it is used in
-    the code, and makes it easier to reference the documentation.
-
-    Attributes:
-      field_len: the length of the field in bytes.
-      field_desc: the field descriptor explaining the data contents.
-      data: the data of the field as a list of integers.
-      data_bytes: the data of the field in byte format.
-    """
-    field_len: int
-    field_desc: int
-    data: Optional[list[int]] = None
-    data_bytes: Optional[bytes] = None
-
-    def __init__(self, field_len: int, field_desc: int,
-                 data: Optional[list[int]] = None,
-                 data_bytes: Optional[bytes] = None):
-        self.field_len = field_len
-        self.field_desc = field_desc
-        # Ensure we load the data from one source, and make sure the alternate
-        # form is consistent.
-        if data is not None:
-            self.data = list(data)
-            self.data_bytes = bytearray(data)
-        elif data_bytes is not None:
-            self.data_bytes = data_bytes
-            self.data = [i for i in data_bytes]
-        else:
-            self.data = []
-            self.data_bytes = b''
-
-    def __len__(self):
-        """Returns length of field data."""
-        data_len = len(self.data) if self.data else 0
-        # Additional 2 for field length and descriptor byte.
-        return 2 + data_len
-    
-    def __iter__(self):
-        """Returns the contents of class (used for unpacking)."""
-        content = [self.field_len, self.field_desc]
-        if self.data:
-            content += self.data
-        return iter(content)
-    
-    @property
-    def as_bytes(self) -> bytes:
-        field_bytes = bytearray([self.field_len, self.field_desc])
-        field_bytes += self.data_bytes
-        return field_bytes
-
-@dataclass
-class MipsPacket:
-    """Container for communication with the device.
-    
-    This class is responsible for properly composing the messages to send to the
-    device. It stores the essential information only, skipping always needed
-    items like the SYNC and checksum components.
-
-    Attributes:
-      desc_set: the descriptor set byte, explaining which message catalog is
-        being sent to the device.
-      payload: a list of MipsField objects, which contain the data to send or
-        what was received from the device.
-      recv_time: a field that can be used to store time a streamed packet
-        arrived, used for decoding and writing out messages.
-    """
-    desc_set: int
-    payload: list[MipsField]
-    recv_time: Optional[float] = None
-
-    def __init__(self, desc_set: int, payload: list[MipsField]):
-        self.desc_set = desc_set
-        self.payload = payload
-        self.payload_len = sum([len(f) for f in self.payload])
-
-    @property
-    def as_bytes(self) -> bytes:
-        """Returns the full packet info as bytes (used to send to device)."""
-        field_bytes = []
-        for entry in self.payload:
-            field_bytes.extend(entry)
-        packet = bytearray([SYNC1, SYNC2, self.desc_set, self.payload_len]
-                           + field_bytes)
-        packet += fletcher_checksum(packet)
-        return packet
-    
-    def convert_payload(self) -> list[collections.namedtuple]:
-        """Converts payload fields to their respective objects."""
-        entries = []
-        for f in self.payload:
-            value = ReplyFormats.process_field(self.desc_set, f)
-            entries.append(value)
-        return entries
-    
-    def flatten_payload(self) -> list[Any]:
-        """Flattens values in payload fields into a list."""
-        processed_fields = self.convert_payload()
-        return list(itertools.chain(*processed_fields))
-
-
-class ReplyFormats:
-    """Container of messages and mapping to formats for unpacking.
-    
-    This class contains a number of helper classes introduced to make it more
-    obvious what's in the data received from the device. It maps the format
-    to the struct unpacking instructions, as well as additional helpful info
-    like the units or info of the terms.
-
-    This class is intended to operate on individual fields, and contains
-    class methods to:
-        - Unpack a field's byte data into an object
-        - Retrieve units for the field
-    """
-    # The ACK/NACK message consists of a command echo and error code.
-    # This comes back when the field description is 0xf1.
-    Ack = collections.namedtuple('Ack', ['cmd_echo', 'error_code'])
-
-    # The device information, note there are lots of spaces in these
-    # fields.
-    DevInfo = collections.namedtuple('DevInfo',[
-        'fw_ver', 'model_name', 'model_number', 'serial_num', 'lot_num',
-        'dev_opts'])
-    
-    DataFmt = collections.namedtuple('DataFmt',
-                                     ['descriptor', 'rate_decimation'])
-
-    # Each set of information stores the format, class, and units of the data.
-    Vector = collections.namedtuple('Vector', ['x', 'y', 'z'])
-    base_set = {
-        0x81: ('>H16s16s16s16s16s', DevInfo),  # Device info.
-        0x83: ('>I', int),  # Built-in self test.
-        0x9b: ('>fff', Vector),  # Gyro bias.
-        0xf1: ('>BB', Ack),  # (N)Ack message.
-    }
-
-    Quat = collections.namedtuple('Quat', ['q0', 'q1', 'q2', 'q3'])
-    Euler = collections.namedtuple('Euler', ['roll', 'pitch', 'yaw'])
-    Matrix = collections.namedtuple('Matrix', ['M11', 'M12', 'M13',
-                                               'M21', 'M22', 'M23',
-                                               'M31', 'M32', 'M33'])
-    Timestamp = collections.namedtuple('GpsTimestamp',
-                                       ['time_of_week', 'week_num', 'flags'])
-    AmbPressure = collections.namedtuple('AmbPressure', ['pressure'])
-
-    imu_set = {
-        0x04: ('>fff', Vector),  # Accelerometer vector.
-        0x05: ('>fff', Vector),  # Gyro vector.
-        0x06: ('>fff', Vector),  # Magnetometer vector.
-        0x07: ('>fff', Vector),  # Delta theta vector.
-        0x08: ('>fff', Vector),  # Delta velocity vector.
-        0x09: ('>fffffffff', Matrix),  # CF orientation matrix.
-        0x0a: ('>ffff', Quat),  # Complimentary filter (CF) quaternion.
-        0x0c: ('>fff', Euler),  # CF Euler Angles.
-        0x10: ('>fff', Vector),  # CF stabilized mag vector.
-        0x11: ('>fff', Vector),  # CF stabilized accel vector.
-        0x12: ('>dHH', Timestamp),  # GPS correlation timestamp.
-        0x17: ('>f', AmbPressure),  # Scaled ambient pressure.
-    }
-
-    imu_units = {
-        0x04: 3*['Accel g'],
-        0x05: 3*['Gyro rad/s'],
-        0x06: 3*['Mag gauss'],
-        0x07: 3*['Delta Theta rad'],
-        0x08: 3*['Delta Vel g*s'],
-        0x09: 9*['n/a'],
-        0x0a: ['q0', 'q1', 'q2', 'q3'],
-        0x0c: 3*['rad'],
-        0x10: 3*['CF Mag gauss'],
-        0x11: 3*['CF Accel g'],
-        0x12: ['sec', 'week', 'n/a'],
-        0x17: ['milliBar'],     
-    }
-
-    GpsLLH = collections.namedtuple(
-        'GpsLLH',['lat', 'lon', 'ellipsoid_ht', 'msl_ht',
-                  'horizontal_acc', 'vertical_acc', 'flags'
-    ])
-    PosECEF = collections.namedtuple(
-        'PosECEF', ['x', 'y', 'z', 'position_acc', 'flags'])
-    VelNED = collections.namedtuple('VelNED', [
-        'north', 'east', 'down', 'speed', 'ground_speed', 'heading',
-        'speed_acc', 'heading_acc', 'flags'
-    ])
-    VelECEF = collections.namedtuple('VelECEF',[
-        'x', 'y', 'z', 'velocity_acc', 'flags'
-    ])
-    Dilution = collections.namedtuple('Dilution', [
-        'geometric_dop', 'position_dop', 'horizontal_dop', 'vertical_dop',
-        'time_dop', 'northing_dop', 'easting_dop', 'flags'
-    ])
-    UTC = collections.namedtuple('UTC', [
-        'year', 'month', 'day', 'hour', 'minute', 'second', 'msec', 'flags'
-    ])
-    GPSTime = collections.namedtuple('GPSTime', [
-        'tow', 'week_num', 'flags'
-    ])
-    ClockInfo = collections.namedtuple('ClockInfo', [
-        'clock_bias', 'clock_drift', 'acc_est', 'flags'
-    ])
-    GPSFix = collections.namedtuple('GPSFix', [
-        'fix_type', 'num_sol_SVs', 'fix_flags', 'valid_flags'
-    ])
-    SvInfo = collections.namedtuple('SvInfo', [
-        'channel', 'sv_id', 'carrier_noise_ratio', 'az', 'el', 'sv_flags',
-        'valid_flags'
-    ])
-    GpsHwStatus = collections.namedtuple('GpsHwStatus', [
-        'sensor_state', 'antenna_state', 'antenna_power', 'flags'
-    ])
-
-    gps_set = {
-        0x03: ('>ddddffH', GpsLLH),
-        0x04: ('>dddfH', PosECEF),
-        0x05: ('>ffffffffH', VelNED),
-        0x06: ('>ffffH', VelECEF),
-        0x07: ('>fffffffH', Dilution),
-        0x08: ('>HBBBBBIH', UTC),
-        0x09: ('>dHH', GPSTime),
-        0x0a: ('>dddH', ClockInfo),
-        0x0b: ('>BBHH', GPSFix),
-        0x0c: ('>BBH2s2sHH', SvInfo),
-        0x0d: ('>BBBH', GpsHwStatus)
-    }
-
-    gps_units = {
-        0x03: ['deg', 'deg', 'm', 'm', 'm', 'm', 'n/a'],
-        0x04: 4*['m'] + ['n/a'],
-        0x05: 5*['m/s'] + ['deg', 'm/s', 'deg', 'n/a'],
-        0x06: 4*['m/s'] + ['n/a'],
-        0x07: 8*['n/a'],
-        0x08: ['years', 'months', 'days', 'hrs', 'min', 'sec', 'ms', 'n/a'],
-        0x09: ['sec', 'week', 'n/a'],
-        0x0a: ['sec', 'sec/sec', 'sec', 'n/a'],
-        0x0b: ['n/a', 'count'] + 2*['n/a'],
-        0x0c: ['chan_num', 'sv_id_num', 'dBHz', 'deg', 'deg'] + 2*['n/a'],
-        0x0d: 4*['n/a']    
-    }
-
-    FilterState = collections.namedtuple(
-        'FilterState', ['state', 'dynamics_mode', 'flags'])
-    EkfLLH = collections.namedtuple(
-        'EkfLLH',['lat', 'lon', 'ellipsoid_ht', 'flags'])
-    EkfVelNED = collections.namedtuple(
-        'EkfVelNED', ['north', 'east', 'down', 'flags'])
-    EkfQuat = collections.namedtuple('EkfQuat', Quat._fields + ('flags',))
-    EkfMatrix = collections.namedtuple('EkfMatrix', Matrix._fields + ('flags',))
-    EkfEuler = collections.namedtuple('EkfEuler', Euler._fields + ('flags',))
-    EkfVector = collections.namedtuple('EkfVector', Vector._fields + ('flags',))
-    UcLLH = collections.namedtuple('UcLLH', 
-        [f'uc_{f}_1sig' for f in ['north', 'east', 'down']] + ['flags'])
-    UcNED = collections.namedtuple('UcNED', UcLLH._fields)
-    UcEuler = collections.namedtuple('UcLLH', 
-        [f'uc_{f}_1sig' for f in ['roll', 'pitch', 'yaw']] + ['flags'])
-    UcVec = collections.namedtuple('UcVec',
-        [f'uc_x_1sig', 'uc_y_1sig', 'uc_z_1sig', 'flags'])
-    Wgs84 = collections.namedtuple('Wgs84', ['grav_mag', 'flags'])
-    UcQuat = collections.namedtuple('UcQuat',
-        [f'uc_{f}_1sig' for f in ['q0', 'q1', 'q2', 'q3']] + ['flags'])
-    EkfHeading = collections.namedtuple('EkfHeading',
-        ['true_heading', 'heading_uc_1sig', 'source', 'flags'])
-    AtmModel = collections.namedtuple('AtmModel',
-        ['geometric_alt', 'geopotential_alt', 'temp', 'pressure', 'density',
-         'flags'])
-    MagModel = collections.namedtuple('MagModel', 
-        ['intensity_north', 'intensity_east', 'intensity_down', 'inclination',
-        'declination', 'flags'])
-    PressureAlt = collections.namedtuple('PressureAlt', ['pressure', 'flags'])
-
-    ekf_set = {
-        0x01: ('>dddH', EkfLLH),  # LLH position.
-        0x02: ('>fffH', EkfVelNED),  # NED velocity.
-        0x03: ('>ffffH', EkfQuat),  # Orientation quaternion.
-        0x04: ('>fffffffffH', EkfMatrix),  # Orientation matrix.
-        0x05: ('>fffH', EkfEuler),  # Orientation euler angles.
-        0x06: ('>fffH', EkfVector),  # Gyro bias.
-        0x07: ('>fffH', EkfVector),  # Accel bias.
-        0x08: ('>fffH', UcLLH),  # LLH position uncertainty.
-        0x09: ('>fffH', UcNED),  # NED velocity uncertainty.
-        0x0a: ('>fffH', UcEuler),  # Attitude uncertainty euler angles.
-        0x0b: ('>fffH', UcVec),  # Gyro bias uncertainty.
-        0x0c: ('>fffH', UcVec),  # Accel bias uncertainty.
-        0x0d: ('>fffH', EkfVector),  # Linear acceleration.  
-        0x0e: ('>fffH', EkfVector),  # Compensated angular rate.
-        0x0f: ('>fH', Wgs84),  # WGS84 local gravity magnitude.
-        0x10: ('>HHH', FilterState),  # Filter status.
-        0x11: ('>dHH', GPSTime),  # GPS timestamp.
-        0x12: ('>ffffH', UcQuat),  # Attitude uncertainty, quat elements.
-        0x13: ('>fffH', EkfVector),  # Gravity vector.
-        0x14: ('>ffHH', EkfHeading),  # Heading update source state.
-        0x15: ('>fffffH', MagModel),  # Magnetic model solution.
-        0x16: ('>fffH', EkfVector),  # Gyro scale factor.
-        0x17: ('>fffH', EkfVector),  # Accel scale factor.
-        0x18: ('>fffH', UcVec),  # Gyro scale factor uncertainty.
-        0x19: ('>fffH', UcVec),  # Accel scale factor uncertainty.
-        0x1c: ('>fffH', EkfVector),  # Compensated linear acceleration.
-        0x20: ('>fffffH', AtmModel),  # Standard atmosphere model.
-        0x21: ('>fH', PressureAlt),  # Pressure altitude.
-        0x30: ('>fffH', EkfVector),  # GPS Antenna offset correction.
-        0x31: ('>fffH', UcVec),  # GPS Antenna offset correction uncertainty.
-    }
-
-    ekf_units = {
-        0x01: 2*['deg'] + ['m', 'n/a'],
-        0x02: 3*['m/s'] + ['n/a'],
-        0x03: 5*['n/a'],
-        0x04: 10*['n/a'],
-        0x05: 3*['rad'] + ['n/a'],
-        0x06: 3*['rad/s'] + ['n/a'],
-        0x07: 3*['m/s2'] + ['n/a'],
-        0x08: 3*['m'] + ['n/a'],
-        0x09: 3*['m/s'] + ['n/a'],
-        0x0a: 3*['rad'] + ['n/a'],
-        0x0b: 3*['rad/s'] + ['n/a'],
-        0x0c: 3*['m/s2'] + ['n/a'],
-        0x0d: 3*['m/s2'] + ['n/a'], 
-        0x0e: 3*['rad/s'] + ['n/a'],
-        0x0f: ['m/s2', 'n/a'],
-        0x10: 3*['n/a'],
-        0x11: ['sec', 'week', 'n/a'],
-        0x12: 5*['n/a'],
-        0x13: 3*['m/s2'] + ['n/a'],
-        0x14: 2*['rad'] + 2*['n/a'],
-        0x15: 3*['gauss'] + 2*['rad'] + ['n/a'],
-        0x16: 3*['%/100'] + ['n/a'],
-        0x17: 3*['%/100'] + ['n/a'],
-        0x18: 3*['%/100'] + ['n/a'],
-        0x19: 3*['%/100'] + ['n/a'],
-        0x1c: 3*['m/s2'] + ['n/a'],
-        0x20: ['m', 'm', 'decC', 'mBar', 'kg/m3', 'n/a'],
-        0x21: ['m', 'n/a'],
-        0x30: 3*['m'] + ['n/a'],
-        0x31: 3*['m'] + ['n/a'],
-    }
-
-    format_map = {
-        0x01: base_set,  # Back commands for all devices.
-        0x0c: base_set,  # To pick up ack/nack for 3DM commands.
-        0x0d: base_set,  # To pick up ack/nack for EKF commands.
-        DataMessages.IMU.msg_ind: imu_set,
-        DataMessages.GPS.msg_ind: gps_set,
-        DataMessages.EKF.msg_ind: ekf_set,
-    }
-
-    @classmethod
-    def process_field(self, desc_set: int,
-                      mips_field: MipsField) -> tuple[any,...]:
-        """Returns processed bytes according to field description."""
-        message_set = self.format_map[desc_set]
-        fmt, obj = message_set[mips_field.field_desc]
-        return obj(*struct.unpack(fmt, mips_field.data_bytes)) 
-    
-    @classmethod
-    def get_field_units(
-        self, desc_set: int, mips_field: MipsField) -> list[str]:
-        """Returns units for MipsField provided."""
-        if desc_set == DataMessages.IMU.msg_ind:
-            units = self.imu_units
-        elif desc_set == DataMessages.GPS.msg_ind:
-            units = self.gps_units
-        elif desc_set == DataMessages.EKF.msg_ind:
-            units = self.ekf_units
-        return units[mips_field.field_desc]
-    
-    @classmethod
-    def decode_ekf_status(self, status: FilterState) -> list[str]:
-        """Translates EKF messages into human readable form."""
-        run_decoder = {
-            0x0001: 'IMU Unavailable',
-            0x0002: 'GPS Unavailable',
-            0x0008: 'Matrix Singularity in calculation',
-            0x0010: 'Position Covariance High Warning',
-            0x0020: 'Velocity Covariance High Warning',
-            0x0040: 'Attitude Covariance High Warning',
-            0x0080: 'NAN in Solution',
-            0x0100: 'Gyro bias estimate high warning',
-            0x0200: 'Accel bias estimate high warning',
-            0x0400: 'Gyro scale factor estimate high warning',
-            0x0800: 'Accel scale factor estimate high warning',
-            0x2000: 'GPS Antenna Offset Correction estimate high warning'
-            }
-        init_decoder = {
-            0x1000: 'Attitude not initialized',
-            0x2000: 'Position & Velocity not initialized'
-            }
-        state_str = ['startup', 'init', 'run', 'error'][status.state]
-        decoder = {0x01: init_decoder, 0x02: run_decoder}[status.state]
-        print(f'EKF in {state_str} phase.')
-        messages = []
-        for key, msg in decoder.items():
-            if key & status.flags:
-                messages.append(msg)
-        return messages
-
-
-def process_mips_packets(
-        packets: list[MipsPacket]) -> list[collections.namedtuple]:
-    """Converts fields of MipsPackets to objects."""
-    return list(itertools.chain.from_iterable(
-        [p.convert_payload() for p in packets]))
-
-
-def divide_mips_packets(
-        packets: list[MipsPacket]) -> tuple[MipsPacket, MipsPacket, MipsPacket]:
-    """Separates MipsPackets into IMU, GPS, and EKF formats."""
-    imu_data = []
-    gps_data = []
-    ekf_data = []
-    for p in packets:
-        if p.desc_set == DataMessages.IMU.msg_ind:
-            imu_data.append(p)
-        elif p.desc_set == DataMessages.GPS.msg_ind:
-            gps_data.append(p)
-        elif p.desc_set == DataMessages.EKF.msg_ind:
-            ekf_data.append(p)
-    return imu_data, gps_data, ekf_data 
-
-
 class Microstrain3DM:
     """An interface for Microstrain 3D motion devices."""
 
@@ -535,30 +76,18 @@ class Microstrain3DM:
         self._ekf_fmt = None
         # This is storage for data collected during streaming.
         self._stream_results = None  # Packets received.
-
-    def _split_payload_to_fields(self, payload: bytes) -> list[MipsField]:
-        """Takes payload bytes and divides them into fields."""
-        index = 0
-        last_byte = len(payload)
-        field_data = []
-        while index < last_byte:
-            field_len = payload[index]
-            field_desc = payload[index + 1]
-            data = payload[index + 2:index + field_len]
-            field_data.append(MipsField(field_len, field_desc, data_bytes=data))
-            index += field_len
-        return field_data
     
-    def _read_one_packet(self) -> MipsPacket:
+    def _read_one_packet(self) -> packets.MipsPacket:
         """Returns the first MipsPacket found on the serial connection."""
-        self._ser.read_until(SYNC_MSG)
+        self._ser.read_until(packets.SYNC_MSG)
         desc_set = self._ser.read(1)
         payload_len = self._ser.read(1)
         payload = self._ser.read(int.from_bytes(payload_len, 'little'))
         checksum = self._ser.read(2)
         self._read_buffer.append(desc_set + payload_len + payload + checksum)
-        field_data = self._split_payload_to_fields(payload)
-        packet = MipsPacket(int.from_bytes(desc_set, 'little'), field_data)
+        field_data = packets.split_payload_to_fields(payload)
+        packet = packets.MipsPacket(int.from_bytes(desc_set, 'little'),
+                                    field_data)
         return packet
     
     def _write(self, value: bytes):
@@ -566,17 +95,17 @@ class Microstrain3DM:
         self._ser.write(value)
         self._write_buffer.append(value)
 
-    def _send_command(self, packet: MipsPacket) -> MipsPacket:
+    def _send_command(self, packet: packets.MipsPacket) -> packets.MipsPacket:
         """Sends command to device and provides response."""
         self._write(packet.as_bytes)
         time.sleep(0.001)
         return self._read_one_packet()
     
-    def _send_and_parse_reply(self, packet: MipsPacket
+    def _send_and_parse_reply(self, packet: packets.MipsPacket
                               ) -> list[collections.namedtuple]:
         """Sends command and returns device reply object."""
         response = self._send_command(packet)
-        return process_mips_packets([response])
+        return packets.process_mips_packets([response])
 
     def dump_read_buffer(self) -> collections.deque:
         return self._read_buffer
@@ -587,31 +116,31 @@ class Microstrain3DM:
     def device_ping(self) -> collections.namedtuple:
         """Sends ping command to device and returns ack message."""
         data = self._send_and_parse_reply(
-            MipsPacket(0x01, [MipsField(0x02, 0x01)]))
+            packets.MipsPacket(0x01, [packets.MipsField(0x02, 0x01)]))
         return data[0]
     
     def device_reset(self) -> collections.namedtuple:
         """Resets device and returns ack message."""
         data = self._send_and_parse_reply(
-            MipsPacket(0x01, [MipsField(0x02, 0x7e)]))
+            packets.MipsPacket(0x01, [packets.MipsField(0x02, 0x7e)]))
         return data[0]
     
     def device_idle(self) -> collections.namedtuple:
         """Sets device into idle mode, which interrupts streaming or sleep."""
         data = self._send_and_parse_reply(
-            MipsPacket(0x01, [MipsField(0x02, 0x02)]))
+            packets.MipsPacket(0x01, [packets.MipsField(0x02, 0x02)]))
         return data[0]
     
     def device_resume(self) -> collections.namedtuple:
         """Sets device into previous or default mode."""
         data = self._send_and_parse_reply(
-            MipsPacket(0x01, [MipsField(0x02, 0x06)]))
+            packets.MipsPacket(0x01, [packets.MipsField(0x02, 0x06)]))
         return data[0]
     
     def device_info(self) -> collections.namedtuple:
         """Returns information for device."""
         data = self._send_and_parse_reply(
-            MipsPacket(0x01, [MipsField(0x02, 0x03)]))
+            packets.MipsPacket(0x01, [packets.MipsField(0x02, 0x03)]))
         return data[1]
     
     def device_built_in_test(self) -> int:
@@ -633,7 +162,7 @@ class Microstrain3DM:
             b1: Solution fault
         """
         data = self._send_and_parse_reply(
-            MipsPacket(0x01,[MipsField(0x02, 0x05)]))
+            packets.MipsPacket(0x01,[packets.MipsField(0x02, 0x05)]))
         return data[1]
     
     def device_baud(self, baud_rate = 115200,
@@ -646,7 +175,7 @@ class Microstrain3DM:
         if baud_rate != self._ser.baudrate:
             # Only send if this will be a change on the hardware side.
             field_bytes = struct.pack('>BI', func_sel.value, baud_rate)
-            cmd = MipsPacket(0x0c, [MipsField(0x07, 0x40,
+            cmd = packets.MipsPacket(0x0c, [packets.MipsField(0x07, 0x40,
                                               data_bytes=field_bytes)])
             self._send_and_parse_reply(cmd)
             time.sleep(0.25)
@@ -655,9 +184,10 @@ class Microstrain3DM:
             self._ser.baudrate = baud_rate
             self._ser.open()
 
-    def device_base_rate(self, msg_type: DataMessages) -> int:
+    def device_base_rate(self, msg_type: packets.DataMessages) -> int:
         """Queries and returns base rate for msg on device."""
-        cmd = MipsPacket(0x0c, [MipsField(0x02, msg_type.rate_cmd)])
+        cmd = packets.MipsPacket(0x0c,
+                                 [packets.MipsField(0x02, msg_type.rate_cmd)])
         response = self._send_command(cmd)
         # This response comes back with a duplicate field descriptor (0x83), so
         # process it locally.
@@ -667,7 +197,7 @@ class Microstrain3DM:
     
     def _generate_field_for_descriptors(
             self, cmd_desc: int, base_rate: float, selector: int,
-            descriptors: list[int], rate_hz: list[float]) -> MipsField:
+            descriptors: list[int], rate_hz: list[float]) -> packets.MipsField:
         """Prepares descriptors to send in message format command."""
         num_descriptors = len(descriptors)
         field_data = [selector, num_descriptors]
@@ -678,12 +208,12 @@ class Microstrain3DM:
             desc_rate = int(base_rate / rate_hz[i])
             field_data.extend([descriptors[i],
                                desc_rate >> 8, desc_rate & 0xff])
-        return MipsField(4 + 3 * num_descriptors, cmd_desc, field_data)
+        return packets.MipsField(4 + 3 * num_descriptors, cmd_desc, field_data)
 
-    def _get_max_rate(self, msg_type: DataMessages) -> float:
-        if msg_type == DataMessages.IMU:
+    def _get_max_rate(self, msg_type: packets.DataMessages) -> float:
+        if msg_type == packets.DataMessages.IMU:
             base_rate = self.IMU_RATE
-        elif msg_type == DataMessages.GPS:
+        elif msg_type == packets.DataMessages.GPS:
             base_rate = self.GPS_RATE
         else:
             base_rate = self.EKF_RATE
@@ -691,9 +221,9 @@ class Microstrain3DM:
     
     def set_msg_fmt(
             self,
-            msg_type: DataMessages = DataMessages.IMU,
+            msg_type: packets.DataMessages = packets.DataMessages.IMU,
             descriptors: list[int] = [0x04],
-            rate_hz: list[float] = [500.]) -> MipsField:
+            rate_hz: list[float] = [500.]) -> packets.MipsField:
         """Sets data format for device msg_type specified.
         
         All data formats are configured with this command. The device can be
@@ -716,10 +246,11 @@ class Microstrain3DM:
         fmt_payload = self._generate_field_for_descriptors(
             msg_type.fmt_cmd, self._get_max_rate(msg_type),
             FunctionSelectors.NEW.value, descriptors, desc_hz)
-        data = self._send_and_parse_reply(MipsPacket(0x0c, [fmt_payload]))
+        data = self._send_and_parse_reply(
+            packets.MipsPacket(0x0c, [fmt_payload]))
         return data[0]
     
-    def _add_descriptors_and_rates(self, msg_type: DataMessages,
+    def _add_descriptors_and_rates(self, msg_type: packets.DataMessages,
                                    descriptors: list[int],
                                    desc_hz: list[float]):
         """Stores descriptors for message type to help divide data later.
@@ -731,49 +262,53 @@ class Microstrain3DM:
         for k in keys:
             desc_for_rate = [d for d, r in zip(descriptors, desc_hz) if r == k]
             update_dict[k] = desc_for_rate
-        if msg_type == DataMessages.IMU:
+        if msg_type == packets.DataMessages.IMU:
             self._imu_fmt = update_dict
-        elif msg_type == DataMessages.GPS:
+        elif msg_type == packets.DataMessages.GPS:
             self._gps_fmt = update_dict
         else:
             self._ekf_fmt = update_dict
     
-    def get_msg_fmt(self,
-                       msg_type: DataMessages = DataMessages.IMU) -> MipsField:
+    def get_msg_fmt(
+            self, msg_type: packets.DataMessages = packets.DataMessages.IMU
+            ) -> packets.MipsField:
         """Returns the message format and decimation factors requested."""
-        cmd = MipsField(0x04, msg_type.fmt_cmd,
-                        [FunctionSelectors.READ_BACK.value, 0x00])
-        data = self._send_command(MipsPacket(0x0c, [cmd]))
+        cmd = packets.MipsField(0x04, msg_type.fmt_cmd,
+                                [FunctionSelectors.READ_BACK.value, 0x00])
+        data = self._send_command(packets.MipsPacket(0x0c, [cmd]))
         # The format will be returned in a field after the ack message, and
         # consist of repeated messages.
         formats = data.payload[1]
         # The number of descriptors is stored in location 0, then the repeated
         # format begins.
-        return [ReplyFormats.DataFmt(*t) for t in
+        return [packets.ReplyFormats.DataFmt(*t) for t in
                 struct.iter_unpack('>BH', formats.data_bytes[1:])]
     
-    def save_msg_fmt(self,
-                        msg_type: DataMessages = DataMessages.IMU) -> MipsField:
+    def save_msg_fmt(
+            self, msg_type: packets.DataMessages = packets.DataMessages.IMU
+            ) -> packets.MipsField:
         """Saves the current settings to apply at startup."""
-        cmd = MipsField(0x04, msg_type.fmt_cmd,
-                        [FunctionSelectors.SAVE.value, 0x00])
-        data = self._send_command(MipsPacket(0x0c, [cmd]))
+        cmd = packets.MipsField(0x04, msg_type.fmt_cmd,
+                                [FunctionSelectors.SAVE.value, 0x00])
+        data = self._send_command(packets.MipsPacket(0x0c, [cmd]))
         return data.convert_payload()
     
     def load_msg_fmt(
-            self, msg_type: DataMessages = DataMessages.IMU) -> MipsField:
+            self, msg_type: packets.DataMessages = packets.DataMessages.IMU
+            ) -> packets.MipsField:
         """Reloads saved settings onto device."""
-        cmd = MipsField(0x04, msg_type.fmt_cmd,
-                        [FunctionSelectors.LOAD.value, 0x00])
-        data = self._send_command(MipsPacket(0x0c, [cmd]))
+        cmd = packets.MipsField(0x04, msg_type.fmt_cmd,
+                                [FunctionSelectors.LOAD.value, 0x00])
+        data = self._send_command(packets.MipsPacket(0x0c, [cmd]))
         return data.convert_payload()
     
     def reset_msg_fmt(
-            self, msg_type: DataMessages = DataMessages.IMU) -> MipsField:
+            self, msg_type: packets.DataMessages = packets.DataMessages.IMU
+            ) -> packets.MipsField:
         """Resets the message format to factory defaults."""
-        cmd = MipsField(0x04, msg_type.fmt_cmd,
-                        [FunctionSelectors.RESET.value, 0x00])
-        data = self._send_command(MipsPacket(0x0c, [cmd]))
+        cmd = packets.MipsField(0x04, msg_type.fmt_cmd,
+                                [FunctionSelectors.RESET.value, 0x00])
+        data = self._send_command(packets.MipsPacket(0x0c, [cmd]))
         # Clear the stored version of the format.
         self._imu_fmt = None
         self._gps_fmt = None
@@ -781,7 +316,7 @@ class Microstrain3DM:
         return data.convert_payload()
     
     def poll_data(
-            self, msg_type: DataMessages = DataMessages.IMU,
+            self, msg_type: packets.DataMessages = packets.DataMessages.IMU,
             suppress_nack: int = 1,  # Default to no nack.
             descriptors: Optional[list[int]] = None
             ) -> list[collections.namedtuple]:
@@ -795,10 +330,10 @@ class Microstrain3DM:
                 msg_type.poll_cmd, 0, suppress_nack, descriptors,
                 num_descriptors * [1])
         else:
-            fmt_field = MipsField(0x04, msg_type.poll_cmd,
-                                   [suppress_nack, 0x00])
+            fmt_field = packets.MipsField(0x04, msg_type.poll_cmd,
+                                          [suppress_nack, 0x00])
         # The poll request suppresses the normal (n)ack reply with option = 1.
-        data = self._send_and_parse_reply(MipsPacket(0x0c, [fmt_field]))
+        data = self._send_and_parse_reply(packets.MipsPacket(0x0c, [fmt_field]))
         return data
     
     def ekf_auto_init(self, func_sel: FunctionSelectors,
@@ -812,20 +347,22 @@ class Microstrain3DM:
           func_sel: how to apply the setting.
           enable: the value to enable (1) or disable (0) auto-initialize.
         """
-        cmd = MipsPacket(0x0d, [MipsField(0x04, 0x19,
-                                          [func_sel.value, enable])])
+        cmd = packets.MipsPacket(
+            0x0d, [packets.MipsField(0x04, 0x19,[func_sel.value, enable])])
         data = self._send_and_parse_reply(cmd)
         return data[0]
     
-    def ekf_euler_init(self, euler_vec: Optional[ReplyFormats.Vector] = None
-                       ) -> collections.namedtuple:
+    def ekf_euler_init(
+            self, euler_vec: Optional[packets.ReplyFormats.Vector] = None
+            ) -> collections.namedtuple:
         """Initializes EKF attitude with euler angles provided."""
         if euler_vec is None:
             # Fetch angles from device.
             euler_vec = self.poll_data(descriptors=[0x0c])[0]
         print(f'Initializing ekf with {euler_vec}')
         vec_bytes = struct.pack('>fff', *euler_vec)
-        cmd = MipsPacket(0x0d, [MipsField(0x0e, 0x02, data_bytes=vec_bytes)])
+        cmd = packets.MipsPacket(
+            0x0d, [packets.MipsField(0x0e, 0x02, data_bytes=vec_bytes)])
         data = self._send_and_parse_reply(cmd)
         return data[0]
 
@@ -843,8 +380,9 @@ class Microstrain3DM:
         Returns:
           The ack/nack message from the command.
         """
-        cmd = MipsPacket(0x0d, [MipsField(0x04, 0x18,
-                                          [func_sel.value, option.value])])
+        cmd = packets.MipsPacket(
+            0x0d, [packets.MipsField(0x04, 0x18,
+                                     [func_sel.value, option.value])])
         data = self._send_and_parse_reply(cmd)
         return data[0]       
     
@@ -862,7 +400,8 @@ class Microstrain3DM:
         if not (1000 <= sample_duration_ms <= 30000):
             raise ValueError(f'Time span {sample_duration_ms} not in range.')
         sample_bytes = struct.pack('>H', sample_duration_ms)
-        cmd = MipsPacket(0x0c, [MipsField(0x04, 0x39, data_bytes=sample_bytes)])
+        cmd = packets.MipsPacket(
+            0x0c, [packets.MipsField(0x04, 0x39, data_bytes=sample_bytes)])
         print(f'Sleeping for {sample_duration_ms} ms to capture bias.')
         # Response will show up after the sleep period.
         response = self._send_command(cmd)
@@ -872,14 +411,14 @@ class Microstrain3DM:
     def set_dynamics_mode(
             self, mode: EkfDynamicsMode,
             func_selector: FunctionSelectors) -> collections.namedtuple:
-        cmd = MipsPacket(0x0d, [MipsField(0x04, 0x10,
+        cmd = packets.MipsPacket(0x0d, [packets.MipsField(0x04, 0x10,
                                           [func_selector.value, mode.value])])
         data = self._send_and_parse_reply(cmd)
         return data[0]
 
     def collect_data_stream(
             self,
-            duration_sec: float = 10.) -> tuple[list[float], list[MipsPacket]]:
+            duration_sec: float = 10.) -> list[packets.MipsPacket]:
         """Collects packets for a time and returns data split to fields.
         
         Prior to calling this, you must have put a format onto the device. This
@@ -910,14 +449,14 @@ class Microstrain3DM:
     
     def _create_file_header_for_fmt(
             self,
-            msg_type: DataMessages,
+            msg_type: packets.DataMessages,
             desc_fmt: dict[float, list[int]]) -> dict[float, str]:
         """Makes a string useable for file header for received data."""
         name = msg_type.name.lower()
         headers = {}
         for rate, descriptors in desc_fmt.items():
-            data_map = getattr(ReplyFormats, name + '_set')
-            data_units = getattr(ReplyFormats, name + '_units')
+            data_map = getattr(packets.ReplyFormats, name + '_set')
+            data_units = getattr(packets.ReplyFormats, name + '_units')
             # Create header for file.
             hdr_line = []
             for d in descriptors:
@@ -933,8 +472,9 @@ class Microstrain3DM:
     def write_stream_data(self, folder: str = './'):
         """Writes stream data to files."""
         # Divide packets by data message type, keep time.
-        processed_data = divide_mips_packets(self._stream_results)
-        message_types = (DataMessages.IMU, DataMessages.GPS, DataMessages.EKF)
+        processed_data = packets.divide_mips_packets(self._stream_results)
+        message_types = (packets.DataMessages.IMU, packets.DataMessages.GPS,
+                         packets.DataMessages.EKF)
         messages = (self._imu_fmt, self._gps_fmt, self._ekf_fmt)
 
         # For each data message collection, pick ones at same rate.

--- a/Microstrain/microstrain_test.py
+++ b/Microstrain/microstrain_test.py
@@ -1,5 +1,6 @@
 from unittest import mock
 import microstrain
+import packets
 import pytest
 
 # Mock out serial for all tests since there is no HW involved.
@@ -7,140 +8,6 @@ import pytest
 def serial_mock():
     with mock.patch.object(microstrain.serial, 'Serial') as _fixture:
         yield _fixture
-
-def test_mips_field_as_bytes_int_construction():
-    sample = microstrain.MipsField(0x06, 0xff, [0x0f, 0x0d, 0x0b, 0x09])
-    assert sample.as_bytes == b'\x06\xff\x0f\x0d\x0b\x09'
-
-def test_mips_data_from_field_bytes_construction():
-    sample = microstrain.MipsField(0x06, 0x11, data_bytes=b'\x02\x04\x06\x08')
-    assert sample.data == [0x02, 0x04, 0x06, 0x08]
-
-def test_mips_field_as_iter():
-    sample = microstrain.MipsField(0x06, 0x11, data_bytes=b'\x02\x04\x06\x08')
-    assert list(sample) == [0x06, 0x11, 0x02, 0x04, 0x06, 0x08]
-
-@pytest.mark.parametrize('name', ['imu', 'gps', 'ekf'])
-def test_formats_and_units_same_length(name):
-    fmts = getattr(microstrain.ReplyFormats, name + '_set')
-    units = getattr(microstrain.ReplyFormats, name + '_units')
-    for ind, vals in units.items():
-        num_units = len(vals)
-        cur_fmt, cur_obj = fmts[ind]
-        # We want to ignore things like the byte symbol, and numbers that
-        # specify the byte length of strings when comparing the two. Thus apply
-        # a filter.
-        num_fmts = len(list(filter(str.isalpha, cur_fmt)))
-        # To unpack properly we need one field per number returned.
-        num_fields = len(cur_obj._fields)
-        assert num_fmts == num_units, f'{name}[{ind}] mismatch!'
-        assert num_fields == num_units, f'{name}[{ind}] field mismatch!'
-
-@pytest.mark.parametrize(
-    'msg_type, field_len, field_desc, data_bytes, expect', [
-        (microstrain.DataMessages.IMU.msg_ind, 0x0e, 0x04,
-         b'\x3e\x7a\x63\xa0xbb\x8e\x3b\x29\x7f\xe5\xbf7f',
-         ['Accel g', 'Accel g', 'Accel g']),
-        (microstrain.DataMessages.GPS.msg_ind, 0x08, 0x0b,
-         b'\x00\x01\x00\x02\x00\x03', ['n/a', 'count', 'n/a', 'n/a']),
-         (microstrain.DataMessages.EKF.msg_ind, 0x10, 0x30,
-          14*b'\x00', ['m', 'm', 'm', 'n/a'])]
-)
-def test_get_units_for_data_message(msg_type, field_len, field_desc, data_bytes,
-                                    expect):
-    field_data = microstrain.MipsField(field_len, field_desc,
-                                       data_bytes=data_bytes)
-    units = microstrain.ReplyFormats.get_field_units(msg_type, field_data)
-    assert units == expect
-
-def test_decode_ekf_status_init_mode():
-    status = microstrain.ReplyFormats.FilterState(1, 1, 0x3000)
-    result = microstrain.ReplyFormats.decode_ekf_status(status)
-    assert len(result) == 2
-
-def test_decode_ekf_status_run_mode():
-    status = microstrain.ReplyFormats.FilterState(2, 1, 0x2ffb)
-    result = microstrain.ReplyFormats.decode_ekf_status(status)
-    assert len(result) == 12
-
-@pytest.mark.parametrize(
-    'payload_bytes, field_list', [
-        # Device reset example - single field case.
-        (b'\x04\xf1\x7e\x00', [
-            microstrain.MipsField(0x04, 0xf1, [0x7e, 0x00])
-        ]),
-        # Save IMU/estimation format - multiple field case.
-        (b'\x04\x08\x03\x00\x04\x0a\x03\x00',
-         [microstrain.MipsField(0x04, 0x08, [0x03, 0x00]),
-          microstrain.MipsField(0x04, 0x0a, [0x03, 0x00])]),
-        # Initialize attitude - note data must be passed in one byte at
-        # a time, even though the 3 values are each 4 bytes.
-        (b'\x0e\x02\xba\xe3\xed\x9b\x3c\x7d\x6d\xdf\xbf\x85\x5c\xf5', [
-            microstrain.MipsField(0x0e, 0x02, [0xba, 0xe3, 0xed, 0x9b,
-                                               0x3c, 0x7d, 0x6d, 0xdf,
-                                               0xbf, 0x85, 0x5c, 0xf5])]),
-        ]
-)
-def test_split_fields_from_payload_data(payload_bytes, field_list):
-    unit = microstrain.Microstrain3DM()
-    result = unit._split_payload_to_fields(payload_bytes)
-    assert result == field_list
-
-@pytest.mark.parametrize(
-    'packet, expected_checksum', [
-        (b'\x75\x65\x01\x02\x02\x01', b'\xe0\xc6'),  # Ping example.
-        (b'\x75\x65\x01\x04\x04\xf1\x01\x00', b'\xd5\x6a'),  # Ping response.
-        (b'\x75\x65\x0c\x0a\x0a\x01\x00\x02\x04\x00\x00\x05\x00\x00',
-         b'\x06\x27')  # Poll IMU.
-    ]
-)
-def test_checksum_calculation(packet, expected_checksum):
-    check_sum = microstrain.fletcher_checksum(packet)
-    assert check_sum == expected_checksum
-
-def test_process_mips_packet():
-    imu_fields = [
-        microstrain.MipsField(
-        0x0e, 0x04, data_bytes=b'?\x80\x00\x00@\x00\x00\x00@@\x00\x00'),
-        microstrain.MipsField(0x06, 0x17, data_bytes=b'?\x80\x00\x00'),
-        microstrain.MipsField(
-        0x12, 0x0a, data_bytes=b'?\x80\x00\x00' + 12*b'\x00')]
-    gps_fields = [microstrain.MipsField(0x08, 0x0b, data = [0, 1, 0, 2, 0, 3])]
-    imu_desc = microstrain.DataMessages.IMU.msg_ind
-    gps_desc = microstrain.DataMessages.GPS.msg_ind
-    packets = [microstrain.MipsPacket(imu_desc, imu_fields),
-               microstrain.MipsPacket(gps_desc, gps_fields)]
-    result = microstrain.process_mips_packets(packets)
-    assert result == [microstrain.ReplyFormats.Vector(1.0, 2.0, 3.0),
-                      microstrain.ReplyFormats.AmbPressure(1.0),
-                      microstrain.ReplyFormats.Quat(1.0, 0, 0, 0),
-                      microstrain.ReplyFormats.GPSFix(0, 1, 2, 3)]
-    
-def test_flatten_payload():
-    gps_fields = [
-        microstrain.MipsField(0x08, 0x0b, data = [0, 1, 0, 2, 0, 3]),
-        microstrain.MipsField(0x0f, 0x08,
-                              data=[0, 4, 5, 6, 7, 8, 9, 0, 0, 0, 10, 0, 11])]
-    gps_desc = microstrain.DataMessages.GPS.msg_ind
-    packet = microstrain.MipsPacket(gps_desc, gps_fields)
-    assert packet.flatten_payload() == [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]
-
-def test_divide_mips_packets():
-    imu_packet = microstrain.MipsPacket(
-        microstrain.DataMessages.IMU.msg_ind,
-        [microstrain.MipsField(0x06, 0x17, data_bytes=b'?\x80\x00\x00')])
-    gps_packet = microstrain.MipsPacket(
-        microstrain.DataMessages.GPS.msg_ind,
-        [microstrain.MipsField(0x08, 0x0b, data = [0, 1, 0, 2, 0, 3])]
-    )
-    ekf_packet = microstrain.MipsPacket(
-        microstrain.DataMessages.EKF.msg_ind,
-        [microstrain.MipsField(0x02, 0xff)]
-    )
-    packets = [imu_packet, gps_packet, ekf_packet, gps_packet, imu_packet,
-               imu_packet]
-    imu, gps, ekf = microstrain.divide_mips_packets(packets)
-    assert (len(imu), len(gps), len(ekf)) == (3, 2, 1)
 
 def test_read_one_packet():
     packet = b'\x01\x0a\x04\xf1\x05\x00\x06\x83\x01\x02\x03\x04\x68\x7d'
@@ -150,9 +17,9 @@ def test_read_one_packet():
     return_vals = (packet[:1], packet[1:2], packet[2:-2], packet[-2:])
     unit._ser.read.side_effect = return_vals
     result = unit._read_one_packet()
-    mips_expected = microstrain.MipsPacket(0x01,[
-        microstrain.MipsField(0x04, 0xf1, [0x05, 0x00]),
-        microstrain.MipsField(0x06, 0x83, [1, 2, 3, 4])])
+    mips_expected = packets.MipsPacket(0x01,[
+        packets.MipsField(0x04, 0xf1, [0x05, 0x00]),
+        packets.MipsField(0x06, 0x83, [1, 2, 3, 4])])
     assert result == mips_expected
 
 def test_ping_command(mocker):
@@ -160,8 +27,8 @@ def test_ping_command(mocker):
     # Test from the read level to make sure the helper _send_and_parse_reply
     # works.
     mock_read = mocker.patch('microstrain.Microstrain3DM._read_one_packet')
-    mock_read.return_value = microstrain.MipsPacket(
-        0x01, [microstrain.MipsField(0x04, 0xf1,
+    mock_read.return_value = packets.MipsPacket(
+        0x01, [packets.MipsField(0x04, 0xf1,
                                         data=[0x01, error_expected])])
     unit = microstrain.Microstrain3DM()
     response = unit.device_ping()  # Ack response received.
@@ -189,12 +56,12 @@ def test_device_command(mocker, command, expected_bytes):
 
 def test_device_base_rate(mocker):
     mock_cmd = mocker.patch('microstrain.Microstrain3DM._send_command')
-    mock_cmd.return_value = microstrain.MipsPacket(
+    mock_cmd.return_value = packets.MipsPacket(
         0x0c,
-        [microstrain.MipsField(0x04, 0xf1, [0x06, 0x00]),
-         microstrain.MipsField(0x04, 0x83, [0x00, 0x64])])
+        [packets.MipsField(0x04, 0xf1, [0x06, 0x00]),
+         packets.MipsField(0x04, 0x83, [0x00, 0x64])])
     unit = microstrain.Microstrain3DM()
-    rate = unit.device_base_rate(microstrain.DataMessages.IMU)
+    rate = unit.device_base_rate(packets.DataMessages.IMU)
     cmd_packet = mock_cmd.call_args[0][0]
     assert cmd_packet.as_bytes == b'\x75\x65\x0c\x02\x02\x06\xf0\xf7'
     assert rate == 100
@@ -215,7 +82,7 @@ def test_set_baud_raises_for_invalid_rate():
 def test_set_imu_format(mocker):
     mock_send = mocker.patch('microstrain.Microstrain3DM._send_and_parse_reply')
     unit = microstrain.Microstrain3DM()
-    unit.set_msg_fmt(microstrain.DataMessages.IMU, [0x04, 0x05], [50.])
+    unit.set_msg_fmt(packets.DataMessages.IMU, [0x04, 0x05], [50.])
     send_packet = mock_send.call_args[0][0]
     expect = b'\x75\x65\x0c\x0a\x0a\x08\x01\x02\x04\x00\x0a\x05\x00\x0a\x22\xa0'
     assert send_packet.as_bytes == expect
@@ -223,7 +90,7 @@ def test_set_imu_format(mocker):
 def test_set_gps_format(mocker):
     mock_send = mocker.patch('microstrain.Microstrain3DM._send_and_parse_reply')
     unit = microstrain.Microstrain3DM()
-    unit.set_msg_fmt(microstrain.DataMessages.GPS, [0x03, 0x05], [1.])
+    unit.set_msg_fmt(packets.DataMessages.GPS, [0x03, 0x05], [1.])
     send_packet = mock_send.call_args[0][0]
     expect = b'\x75\x65\x0c\x0a\x0a\x09\x01\x02\x03\x00\x04\x05\x00\x04\x16\x85'
     assert send_packet.as_bytes == expect
@@ -231,7 +98,7 @@ def test_set_gps_format(mocker):
 def test_set_estimation_filter_format(mocker):
     mock_send = mocker.patch('microstrain.Microstrain3DM._send_and_parse_reply')
     unit = microstrain.Microstrain3DM()
-    unit.set_msg_fmt(microstrain.DataMessages.EKF, [0x01, 0x02], [500.])
+    unit.set_msg_fmt(packets.DataMessages.EKF, [0x01, 0x02], [500.])
     send_packet = mock_send.call_args[0][0]
     expect = b'\x75\x65\x0c\x0a\x0a\x0a\x01\x02\x01\x00\x01\x02\x00\x01\x0c\x6a'
     assert send_packet.as_bytes == expect
@@ -247,21 +114,21 @@ def test_set_dynamics_mode(mocker):
 
 def test_get_msg_format_for_gps(mocker):
     mock_cmd = mocker.patch('microstrain.Microstrain3DM._send_command')
-    mock_cmd.return_value = microstrain.MipsPacket(0x0c,[
-        microstrain.MipsField(0x04, 0xf1, [0x09, 0x00]),
-        microstrain.MipsField(0x06, 0x81, [0x01, 0x03, 0x00, 0x04])
+    mock_cmd.return_value = packets.MipsPacket(0x0c,[
+        packets.MipsField(0x04, 0xf1, [0x09, 0x00]),
+        packets.MipsField(0x06, 0x81, [0x01, 0x03, 0x00, 0x04])
     ])
     unit = microstrain.Microstrain3DM()
-    formats = unit.get_msg_fmt(microstrain.DataMessages.GPS)
+    formats = unit.get_msg_fmt(packets.DataMessages.GPS)
     send_packet = mock_cmd.call_args[0][0]
     expect = b'\x75\x65\x0c\x04\x04\x09\x02\x00\xf9\xf6'
     assert send_packet.as_bytes == expect
-    assert formats == [microstrain.ReplyFormats.DataFmt(0x03, 0x04)]
+    assert formats == [packets.ReplyFormats.DataFmt(0x03, 0x04)]
 
 def test_save_msg_format_for_estimation_filter(mocker):
     mock_cmd = mocker.patch('microstrain.Microstrain3DM._send_command')
     unit = microstrain.Microstrain3DM()
-    unit.save_msg_fmt(microstrain.DataMessages.EKF)
+    unit.save_msg_fmt(packets.DataMessages.EKF)
     send_packet = mock_cmd.call_args[0][0]
     expect = b'\x75\x65\x0c\x04\x04\x0a\x03\x00\xfb\xfb'
     assert send_packet.as_bytes == expect
@@ -269,7 +136,7 @@ def test_save_msg_format_for_estimation_filter(mocker):
 def test_load_msg_format_for_imu(mocker):
     mock_cmd = mocker.patch('microstrain.Microstrain3DM._send_command')
     unit = microstrain.Microstrain3DM()
-    unit.load_msg_fmt(microstrain.DataMessages.IMU)
+    unit.load_msg_fmt(packets.DataMessages.IMU)
     send_packet = mock_cmd.call_args[0][0]
     expect = b'\x75\x65\x0c\x04\x04\x08\x04\x00\xfa\xf7'
     assert send_packet.as_bytes == expect
@@ -277,7 +144,7 @@ def test_load_msg_format_for_imu(mocker):
 def test_reset_msg_format_for_gps(mocker):
     mock_cmd = mocker.patch('microstrain.Microstrain3DM._send_command')
     unit = microstrain.Microstrain3DM()
-    unit.reset_msg_fmt(microstrain.DataMessages.GPS)
+    unit.reset_msg_fmt(packets.DataMessages.GPS)
     send_packet = mock_cmd.call_args[0][0]
     expect = b'\x75\x65\x0c\x04\x04\x09\x05\x00\xfc\xfc'
     assert send_packet.as_bytes == expect
@@ -285,7 +152,7 @@ def test_reset_msg_format_for_gps(mocker):
 def test_poll_data_for_estimation_filter(mocker):
     mock_send = mocker.patch('microstrain.Microstrain3DM._send_and_parse_reply')
     unit = microstrain.Microstrain3DM()
-    unit.poll_data(microstrain.DataMessages.EKF)
+    unit.poll_data(packets.DataMessages.EKF)
     send_packet = mock_send.call_args[0][0]
     expect = b'\x75\x65\x0c\x04\x04\x03\x01\x00\xf2\xe2'
     assert send_packet.as_bytes == expect
@@ -293,7 +160,7 @@ def test_poll_data_for_estimation_filter(mocker):
 def test_poll_data_for_imu_format(mocker):
     mock_send = mocker.patch('microstrain.Microstrain3DM._send_and_parse_reply')
     unit = microstrain.Microstrain3DM()
-    unit.poll_data(microstrain.DataMessages.IMU, suppress_nack=0,
+    unit.poll_data(packets.DataMessages.IMU, suppress_nack=0,
                    descriptors=[0x04, 0x05])
     send_packet = mock_send.call_args[0][0]
     expect = b'\x75\x65\x0c\x0a\x0a\x01\x00\x02\x04\x00\x00\x05\x00\x00\x06\x27'
@@ -310,7 +177,7 @@ def test_ekf_auto_initialize(mocker):
 def test_ekf_euler_initialize(mocker):
     mock_send = mocker.patch('microstrain.Microstrain3DM._send_and_parse_reply')
     unit = microstrain.Microstrain3DM()
-    unit.ekf_euler_init(microstrain.ReplyFormats.Vector(0, 0, 0))
+    unit.ekf_euler_init(packets.ReplyFormats.Vector(0, 0, 0))
     send_packet = mock_send.call_args[0][0]
     expect = b'\x75\x65\x0d\x0e\x0e\x02' + 12*b'\x00' + b'\x05\x6f'
     assert send_packet.as_bytes == expect
@@ -340,7 +207,7 @@ def test_capture_gyro_bias(mocker):
 def test_create_headers_for_file():
     unit = microstrain.Microstrain3DM()
     header = unit._create_file_header_for_fmt(
-        microstrain.DataMessages.IMU, {1.0: [0x04, 0x06], 2.0: [0x17]})
+        packets.DataMessages.IMU, {1.0: [0x04, 0x06], 2.0: [0x17]})
     expect = {1.0: ['x (Accel g)', 'y (Accel g)', 'z (Accel g)',
                     'x (Mag gauss)', 'y (Mag gauss)', 'z (Mag gauss)'],
               2.0: ['pressure (milliBar)']}
@@ -363,9 +230,9 @@ def test_write_stream_data(mocker):
     mock_open = mocker.patch('builtins.open')
     unit = microstrain.Microstrain3DM()
     unit._stream_results = [
-        microstrain.MipsPacket(
-            microstrain.DataMessages.IMU.msg_ind,
-            [microstrain.MipsField(0x06, 0x17, data_bytes=b'?\x80\x00\x00')])]
+        packets.MipsPacket(
+            packets.DataMessages.IMU.msg_ind,
+            [packets.MipsField(0x06, 0x17, data_bytes=b'?\x80\x00\x00')])]
     unit._imu_fmt = {1.0: [0x17]}
     unit.write_stream_data()
     # Make sure import info in file name.

--- a/Microstrain/packets.py
+++ b/Microstrain/packets.py
@@ -1,0 +1,480 @@
+r"""Helper library for handling packets from the microstrain device.
+
+Helper dataclasses are introduced:
+  MipsField: are strung together as a list and packed into the payload portion
+    of the packet.
+  MipsPacket: the top level container that describes the payload and holds all
+    the data.
+  ReplyFormats: provide a mapping between packets and the data to make it easier
+    to decode.
+"""
+
+import collections
+from dataclasses import dataclass
+import enum
+import itertools
+import struct
+from typing import Any, Optional
+
+# The sync headers are always the same, and indicate the start of a packet.
+SYNC1 = 0x75
+SYNC2 = 0x65
+SYNC_MSG = bytearray([SYNC1, SYNC2])
+
+class DataMessages(enum.Enum):
+    """Small class to bundle interactions with the different message formats.
+    
+    Attributes:
+      msg_ind: the packet descriptor for a message of that type.
+      fmt_cmd: the field descriptor portion of the format command.
+      poll_cmd: the field desecriptor portion of the poll command.  
+    """
+    IMU = (0x80, 0x08, 0x01, 0x06)
+    GPS = (0x81, 0x09, 0x02, 0x07)
+    EKF = (0x82, 0x0a, 0x03, 0x0b)
+
+    def __init__(self, msg_ind, fmt_cmd, poll_cmd, rate_cmd):
+        self.msg_ind = msg_ind
+        self.fmt_cmd = fmt_cmd
+        self.poll_cmd = poll_cmd
+        self.rate_cmd = rate_cmd
+
+@dataclass
+class MipsField:
+    """Container that represents the payload data in the MipsPacket.
+    
+    For convenience, the data held in the MipsField is represented in both byte
+    and as a list of integers. This gives some flexibility in how it is used in
+    the code, and makes it easier to reference the documentation.
+
+    Attributes:
+      field_len: the length of the field in bytes.
+      field_desc: the field descriptor explaining the data contents.
+      data: the data of the field as a list of integers.
+      data_bytes: the data of the field in byte format.
+    """
+    field_len: int
+    field_desc: int
+    data: Optional[list[int]] = None
+    data_bytes: Optional[bytes] = None
+
+    def __init__(self, field_len: int, field_desc: int,
+                 data: Optional[list[int]] = None,
+                 data_bytes: Optional[bytes] = None):
+        self.field_len = field_len
+        self.field_desc = field_desc
+        # Ensure we load the data from one source, and make sure the alternate
+        # form is consistent.
+        if data is not None:
+            self.data = list(data)
+            self.data_bytes = bytearray(data)
+        elif data_bytes is not None:
+            self.data_bytes = data_bytes
+            self.data = [i for i in data_bytes]
+        else:
+            self.data = []
+            self.data_bytes = b''
+
+    def __len__(self):
+        """Returns length of field data."""
+        data_len = len(self.data) if self.data else 0
+        # Additional 2 for field length and descriptor byte.
+        return 2 + data_len
+    
+    def __iter__(self):
+        """Returns the contents of class (used for unpacking)."""
+        content = [self.field_len, self.field_desc]
+        if self.data:
+            content += self.data
+        return iter(content)
+    
+    @property
+    def as_bytes(self) -> bytes:
+        field_bytes = bytearray([self.field_len, self.field_desc])
+        field_bytes += self.data_bytes
+        return field_bytes
+
+@dataclass
+class MipsPacket:
+    """Container for communication with the device.
+    
+    This class is responsible for properly composing the messages to send to the
+    device. It stores the essential information only, skipping always needed
+    items like the SYNC and checksum components.
+
+    Attributes:
+      desc_set: the descriptor set byte, explaining which message catalog is
+        being sent to the device.
+      payload: a list of MipsField objects, which contain the data to send or
+        what was received from the device.
+      recv_time: a field that can be used to store time a streamed packet
+        arrived, used for decoding and writing out messages.
+    """
+    desc_set: int
+    payload: list[MipsField]
+    recv_time: Optional[float] = None
+
+    def __init__(self, desc_set: int, payload: list[MipsField]):
+        self.desc_set = desc_set
+        self.payload = payload
+        self.payload_len = sum([len(f) for f in self.payload])
+
+    @property
+    def as_bytes(self) -> bytes:
+        """Returns the full packet info as bytes (used to send to device)."""
+        field_bytes = []
+        for entry in self.payload:
+            field_bytes.extend(entry)
+        packet = bytearray([SYNC1, SYNC2, self.desc_set, self.payload_len]
+                           + field_bytes)
+        packet += fletcher_checksum(packet)
+        return packet
+    
+    def convert_payload(self) -> list[collections.namedtuple]:
+        """Converts payload fields to their respective objects."""
+        entries = []
+        for f in self.payload:
+            value = ReplyFormats.process_field(self.desc_set, f)
+            entries.append(value)
+        return entries
+    
+    def flatten_payload(self) -> list[Any]:
+        """Flattens values in payload fields into a list."""
+        processed_fields = self.convert_payload()
+        return list(itertools.chain(*processed_fields))
+
+def split_payload_to_fields(payload: bytes) -> list[MipsField]:
+    """Takes payload bytes and divides them into fields."""
+    index = 0
+    last_byte = len(payload)
+    field_data = []
+    while index < last_byte:
+        field_len = payload[index]
+        field_desc = payload[index + 1]
+        data = payload[index + 2:index + field_len]
+        field_data.append(MipsField(field_len, field_desc, data_bytes=data))
+        index += field_len
+    return field_data
+
+class ReplyFormats:
+    """Container of messages and mapping to formats for unpacking.
+    
+    This class contains a number of helper classes introduced to make it more
+    obvious what's in the data received from the device. It maps the format
+    to the struct unpacking instructions, as well as additional helpful info
+    like the units or info of the terms.
+
+    This class is intended to operate on individual fields, and contains
+    class methods to:
+        - Unpack a field's byte data into an object
+        - Retrieve units for the field
+    """
+    # The ACK/NACK message consists of a command echo and error code.
+    # This comes back when the field description is 0xf1.
+    Ack = collections.namedtuple('Ack', ['cmd_echo', 'error_code'])
+
+    # The device information, note there are lots of spaces in these
+    # fields.
+    DevInfo = collections.namedtuple('DevInfo',[
+        'fw_ver', 'model_name', 'model_number', 'serial_num', 'lot_num',
+        'dev_opts'])
+    
+    DataFmt = collections.namedtuple('DataFmt',
+                                     ['descriptor', 'rate_decimation'])
+
+    # Each set of information stores the format, class, and units of the data.
+    Vector = collections.namedtuple('Vector', ['x', 'y', 'z'])
+    base_set = {
+        0x81: ('>H16s16s16s16s16s', DevInfo),  # Device info.
+        0x83: ('>I', int),  # Built-in self test.
+        0x9b: ('>fff', Vector),  # Gyro bias.
+        0xf1: ('>BB', Ack),  # (N)Ack message.
+    }
+
+    Quat = collections.namedtuple('Quat', ['q0', 'q1', 'q2', 'q3'])
+    Euler = collections.namedtuple('Euler', ['roll', 'pitch', 'yaw'])
+    Matrix = collections.namedtuple('Matrix', ['M11', 'M12', 'M13',
+                                               'M21', 'M22', 'M23',
+                                               'M31', 'M32', 'M33'])
+    Timestamp = collections.namedtuple('GpsTimestamp',
+                                       ['time_of_week', 'week_num', 'flags'])
+    AmbPressure = collections.namedtuple('AmbPressure', ['pressure'])
+
+    imu_set = {
+        0x04: ('>fff', Vector),  # Accelerometer vector.
+        0x05: ('>fff', Vector),  # Gyro vector.
+        0x06: ('>fff', Vector),  # Magnetometer vector.
+        0x07: ('>fff', Vector),  # Delta theta vector.
+        0x08: ('>fff', Vector),  # Delta velocity vector.
+        0x09: ('>fffffffff', Matrix),  # CF orientation matrix.
+        0x0a: ('>ffff', Quat),  # Complimentary filter (CF) quaternion.
+        0x0c: ('>fff', Euler),  # CF Euler Angles.
+        0x10: ('>fff', Vector),  # CF stabilized mag vector.
+        0x11: ('>fff', Vector),  # CF stabilized accel vector.
+        0x12: ('>dHH', Timestamp),  # GPS correlation timestamp.
+        0x17: ('>f', AmbPressure),  # Scaled ambient pressure.
+    }
+
+    imu_units = {
+        0x04: 3*['Accel g'],
+        0x05: 3*['Gyro rad/s'],
+        0x06: 3*['Mag gauss'],
+        0x07: 3*['Delta Theta rad'],
+        0x08: 3*['Delta Vel g*s'],
+        0x09: 9*['n/a'],
+        0x0a: ['q0', 'q1', 'q2', 'q3'],
+        0x0c: 3*['rad'],
+        0x10: 3*['CF Mag gauss'],
+        0x11: 3*['CF Accel g'],
+        0x12: ['sec', 'week', 'n/a'],
+        0x17: ['milliBar'],     
+    }
+
+    GpsLLH = collections.namedtuple(
+        'GpsLLH',['lat', 'lon', 'ellipsoid_ht', 'msl_ht',
+                  'horizontal_acc', 'vertical_acc', 'flags'
+    ])
+    PosECEF = collections.namedtuple(
+        'PosECEF', ['x', 'y', 'z', 'position_acc', 'flags'])
+    VelNED = collections.namedtuple('VelNED', [
+        'north', 'east', 'down', 'speed', 'ground_speed', 'heading',
+        'speed_acc', 'heading_acc', 'flags'
+    ])
+    VelECEF = collections.namedtuple('VelECEF',[
+        'x', 'y', 'z', 'velocity_acc', 'flags'
+    ])
+    Dilution = collections.namedtuple('Dilution', [
+        'geometric_dop', 'position_dop', 'horizontal_dop', 'vertical_dop',
+        'time_dop', 'northing_dop', 'easting_dop', 'flags'
+    ])
+    UTC = collections.namedtuple('UTC', [
+        'year', 'month', 'day', 'hour', 'minute', 'second', 'msec', 'flags'
+    ])
+    GPSTime = collections.namedtuple('GPSTime', [
+        'tow', 'week_num', 'flags'
+    ])
+    ClockInfo = collections.namedtuple('ClockInfo', [
+        'clock_bias', 'clock_drift', 'acc_est', 'flags'
+    ])
+    GPSFix = collections.namedtuple('GPSFix', [
+        'fix_type', 'num_sol_SVs', 'fix_flags', 'valid_flags'
+    ])
+    SvInfo = collections.namedtuple('SvInfo', [
+        'channel', 'sv_id', 'carrier_noise_ratio', 'az', 'el', 'sv_flags',
+        'valid_flags'
+    ])
+    GpsHwStatus = collections.namedtuple('GpsHwStatus', [
+        'sensor_state', 'antenna_state', 'antenna_power', 'flags'
+    ])
+
+    gps_set = {
+        0x03: ('>ddddffH', GpsLLH),
+        0x04: ('>dddfH', PosECEF),
+        0x05: ('>ffffffffH', VelNED),
+        0x06: ('>ffffH', VelECEF),
+        0x07: ('>fffffffH', Dilution),
+        0x08: ('>HBBBBBIH', UTC),
+        0x09: ('>dHH', GPSTime),
+        0x0a: ('>dddH', ClockInfo),
+        0x0b: ('>BBHH', GPSFix),
+        0x0c: ('>BBH2s2sHH', SvInfo),
+        0x0d: ('>BBBH', GpsHwStatus)
+    }
+
+    gps_units = {
+        0x03: ['deg', 'deg', 'm', 'm', 'm', 'm', 'n/a'],
+        0x04: 4*['m'] + ['n/a'],
+        0x05: 5*['m/s'] + ['deg', 'm/s', 'deg', 'n/a'],
+        0x06: 4*['m/s'] + ['n/a'],
+        0x07: 8*['n/a'],
+        0x08: ['years', 'months', 'days', 'hrs', 'min', 'sec', 'ms', 'n/a'],
+        0x09: ['sec', 'week', 'n/a'],
+        0x0a: ['sec', 'sec/sec', 'sec', 'n/a'],
+        0x0b: ['n/a', 'count'] + 2*['n/a'],
+        0x0c: ['chan_num', 'sv_id_num', 'dBHz', 'deg', 'deg'] + 2*['n/a'],
+        0x0d: 4*['n/a']    
+    }
+
+    FilterState = collections.namedtuple(
+        'FilterState', ['state', 'dynamics_mode', 'flags'])
+    EkfLLH = collections.namedtuple(
+        'EkfLLH',['lat', 'lon', 'ellipsoid_ht', 'flags'])
+    EkfVelNED = collections.namedtuple(
+        'EkfVelNED', ['north', 'east', 'down', 'flags'])
+    EkfQuat = collections.namedtuple('EkfQuat', Quat._fields + ('flags',))
+    EkfMatrix = collections.namedtuple('EkfMatrix', Matrix._fields + ('flags',))
+    EkfEuler = collections.namedtuple('EkfEuler', Euler._fields + ('flags',))
+    EkfVector = collections.namedtuple('EkfVector', Vector._fields + ('flags',))
+    UcLLH = collections.namedtuple('UcLLH', 
+        [f'uc_{f}_1sig' for f in ['north', 'east', 'down']] + ['flags'])
+    UcNED = collections.namedtuple('UcNED', UcLLH._fields)
+    UcEuler = collections.namedtuple('UcLLH', 
+        [f'uc_{f}_1sig' for f in ['roll', 'pitch', 'yaw']] + ['flags'])
+    UcVec = collections.namedtuple('UcVec',
+        [f'uc_x_1sig', 'uc_y_1sig', 'uc_z_1sig', 'flags'])
+    Wgs84 = collections.namedtuple('Wgs84', ['grav_mag', 'flags'])
+    UcQuat = collections.namedtuple('UcQuat',
+        [f'uc_{f}_1sig' for f in ['q0', 'q1', 'q2', 'q3']] + ['flags'])
+    EkfHeading = collections.namedtuple('EkfHeading',
+        ['true_heading', 'heading_uc_1sig', 'source', 'flags'])
+    AtmModel = collections.namedtuple('AtmModel',
+        ['geometric_alt', 'geopotential_alt', 'temp', 'pressure', 'density',
+         'flags'])
+    MagModel = collections.namedtuple('MagModel', 
+        ['intensity_north', 'intensity_east', 'intensity_down', 'inclination',
+        'declination', 'flags'])
+    PressureAlt = collections.namedtuple('PressureAlt', ['pressure', 'flags'])
+
+    ekf_set = {
+        0x01: ('>dddH', EkfLLH),  # LLH position.
+        0x02: ('>fffH', EkfVelNED),  # NED velocity.
+        0x03: ('>ffffH', EkfQuat),  # Orientation quaternion.
+        0x04: ('>fffffffffH', EkfMatrix),  # Orientation matrix.
+        0x05: ('>fffH', EkfEuler),  # Orientation euler angles.
+        0x06: ('>fffH', EkfVector),  # Gyro bias.
+        0x07: ('>fffH', EkfVector),  # Accel bias.
+        0x08: ('>fffH', UcLLH),  # LLH position uncertainty.
+        0x09: ('>fffH', UcNED),  # NED velocity uncertainty.
+        0x0a: ('>fffH', UcEuler),  # Attitude uncertainty euler angles.
+        0x0b: ('>fffH', UcVec),  # Gyro bias uncertainty.
+        0x0c: ('>fffH', UcVec),  # Accel bias uncertainty.
+        0x0d: ('>fffH', EkfVector),  # Linear acceleration.  
+        0x0e: ('>fffH', EkfVector),  # Compensated angular rate.
+        0x0f: ('>fH', Wgs84),  # WGS84 local gravity magnitude.
+        0x10: ('>HHH', FilterState),  # Filter status.
+        0x11: ('>dHH', GPSTime),  # GPS timestamp.
+        0x12: ('>ffffH', UcQuat),  # Attitude uncertainty, quat elements.
+        0x13: ('>fffH', EkfVector),  # Gravity vector.
+        0x14: ('>ffHH', EkfHeading),  # Heading update source state.
+        0x15: ('>fffffH', MagModel),  # Magnetic model solution.
+        0x16: ('>fffH', EkfVector),  # Gyro scale factor.
+        0x17: ('>fffH', EkfVector),  # Accel scale factor.
+        0x18: ('>fffH', UcVec),  # Gyro scale factor uncertainty.
+        0x19: ('>fffH', UcVec),  # Accel scale factor uncertainty.
+        0x1c: ('>fffH', EkfVector),  # Compensated linear acceleration.
+        0x20: ('>fffffH', AtmModel),  # Standard atmosphere model.
+        0x21: ('>fH', PressureAlt),  # Pressure altitude.
+        0x30: ('>fffH', EkfVector),  # GPS Antenna offset correction.
+        0x31: ('>fffH', UcVec),  # GPS Antenna offset correction uncertainty.
+    }
+
+    ekf_units = {
+        0x01: 2*['deg'] + ['m', 'n/a'],
+        0x02: 3*['m/s'] + ['n/a'],
+        0x03: 5*['n/a'],
+        0x04: 10*['n/a'],
+        0x05: 3*['rad'] + ['n/a'],
+        0x06: 3*['rad/s'] + ['n/a'],
+        0x07: 3*['m/s2'] + ['n/a'],
+        0x08: 3*['m'] + ['n/a'],
+        0x09: 3*['m/s'] + ['n/a'],
+        0x0a: 3*['rad'] + ['n/a'],
+        0x0b: 3*['rad/s'] + ['n/a'],
+        0x0c: 3*['m/s2'] + ['n/a'],
+        0x0d: 3*['m/s2'] + ['n/a'], 
+        0x0e: 3*['rad/s'] + ['n/a'],
+        0x0f: ['m/s2', 'n/a'],
+        0x10: 3*['n/a'],
+        0x11: ['sec', 'week', 'n/a'],
+        0x12: 5*['n/a'],
+        0x13: 3*['m/s2'] + ['n/a'],
+        0x14: 2*['rad'] + 2*['n/a'],
+        0x15: 3*['gauss'] + 2*['rad'] + ['n/a'],
+        0x16: 3*['%/100'] + ['n/a'],
+        0x17: 3*['%/100'] + ['n/a'],
+        0x18: 3*['%/100'] + ['n/a'],
+        0x19: 3*['%/100'] + ['n/a'],
+        0x1c: 3*['m/s2'] + ['n/a'],
+        0x20: ['m', 'm', 'decC', 'mBar', 'kg/m3', 'n/a'],
+        0x21: ['m', 'n/a'],
+        0x30: 3*['m'] + ['n/a'],
+        0x31: 3*['m'] + ['n/a'],
+    }
+
+    format_map = {
+        0x01: base_set,  # Back commands for all devices.
+        0x0c: base_set,  # To pick up ack/nack for 3DM commands.
+        0x0d: base_set,  # To pick up ack/nack for EKF commands.
+        DataMessages.IMU.msg_ind: imu_set,
+        DataMessages.GPS.msg_ind: gps_set,
+        DataMessages.EKF.msg_ind: ekf_set,
+    }
+
+    @classmethod
+    def process_field(self, desc_set: int,
+                      mips_field: MipsField) -> tuple[any,...]:
+        """Returns processed bytes according to field description."""
+        message_set = self.format_map[desc_set]
+        fmt, obj = message_set[mips_field.field_desc]
+        return obj(*struct.unpack(fmt, mips_field.data_bytes)) 
+    
+    @classmethod
+    def get_field_units(
+        self, desc_set: int, mips_field: MipsField) -> list[str]:
+        """Returns units for MipsField provided."""
+        if desc_set == DataMessages.IMU.msg_ind:
+            units = self.imu_units
+        elif desc_set == DataMessages.GPS.msg_ind:
+            units = self.gps_units
+        elif desc_set == DataMessages.EKF.msg_ind:
+            units = self.ekf_units
+        return units[mips_field.field_desc]
+    
+    @classmethod
+    def decode_ekf_status(self, status: FilterState) -> list[str]:
+        """Translates EKF messages into human readable form."""
+        run_decoder = {
+            0x0001: 'IMU Unavailable',
+            0x0002: 'GPS Unavailable',
+            0x0008: 'Matrix Singularity in calculation',
+            0x0010: 'Position Covariance High Warning',
+            0x0020: 'Velocity Covariance High Warning',
+            0x0040: 'Attitude Covariance High Warning',
+            0x0080: 'NAN in Solution',
+            0x0100: 'Gyro bias estimate high warning',
+            0x0200: 'Accel bias estimate high warning',
+            0x0400: 'Gyro scale factor estimate high warning',
+            0x0800: 'Accel scale factor estimate high warning',
+            0x2000: 'GPS Antenna Offset Correction estimate high warning'
+            }
+        init_decoder = {
+            0x1000: 'Attitude not initialized',
+            0x2000: 'Position & Velocity not initialized'
+            }
+        state_str = ['startup', 'init', 'run', 'error'][status.state]
+        decoder = {0x01: init_decoder, 0x02: run_decoder}[status.state]
+        print(f'EKF in {state_str} phase.')
+        messages = []
+        for key, msg in decoder.items():
+            if key & status.flags:
+                messages.append(msg)
+        return messages
+
+
+def fletcher_checksum(packet: bytes) -> bytes:
+    """Calculates fletcher checksum for bytes in packet."""
+    check_sum = [sum(packet), sum(itertools.accumulate(packet))]
+    return bytearray([0xff & check_sum[0], 0xff & check_sum[1]])
+
+
+def process_mips_packets(
+        packets: list[MipsPacket]) -> list[collections.namedtuple]:
+    """Converts fields of MipsPackets to objects."""
+    return list(itertools.chain.from_iterable(
+        [p.convert_payload() for p in packets]))
+
+
+def divide_mips_packets(
+        packets: list[MipsPacket]) -> tuple[MipsPacket, MipsPacket, MipsPacket]:
+    """Separates MipsPackets into IMU, GPS, and EKF formats."""
+    imu_data = []
+    gps_data = []
+    ekf_data = []
+    for p in packets:
+        if p.desc_set == DataMessages.IMU.msg_ind:
+            imu_data.append(p)
+        elif p.desc_set == DataMessages.GPS.msg_ind:
+            gps_data.append(p)
+        elif p.desc_set == DataMessages.EKF.msg_ind:
+            ekf_data.append(p)
+    return imu_data, gps_data, ekf_data

--- a/Microstrain/packets_test.py
+++ b/Microstrain/packets_test.py
@@ -1,0 +1,136 @@
+from unittest import mock
+import packets
+import pytest
+
+def test_mips_field_as_bytes_int_construction():
+    sample = packets.MipsField(0x06, 0xff, [0x0f, 0x0d, 0x0b, 0x09])
+    assert sample.as_bytes == b'\x06\xff\x0f\x0d\x0b\x09'
+
+def test_mips_data_from_field_bytes_construction():
+    sample = packets.MipsField(0x06, 0x11, data_bytes=b'\x02\x04\x06\x08')
+    assert sample.data == [0x02, 0x04, 0x06, 0x08]
+
+def test_mips_field_as_iter():
+    sample = packets.MipsField(0x06, 0x11, data_bytes=b'\x02\x04\x06\x08')
+    assert list(sample) == [0x06, 0x11, 0x02, 0x04, 0x06, 0x08]
+
+@pytest.mark.parametrize('name', ['imu', 'gps', 'ekf'])
+def test_formats_and_units_same_length(name):
+    fmts = getattr(packets.ReplyFormats, name + '_set')
+    units = getattr(packets.ReplyFormats, name + '_units')
+    for ind, vals in units.items():
+        num_units = len(vals)
+        cur_fmt, cur_obj = fmts[ind]
+        # We want to ignore things like the byte symbol, and numbers that
+        # specify the byte length of strings when comparing the two. Thus apply
+        # a filter.
+        num_fmts = len(list(filter(str.isalpha, cur_fmt)))
+        # To unpack properly we need one field per number returned.
+        num_fields = len(cur_obj._fields)
+        assert num_fmts == num_units, f'{name}[{ind}] mismatch!'
+        assert num_fields == num_units, f'{name}[{ind}] field mismatch!'
+
+@pytest.mark.parametrize(
+    'msg_type, field_len, field_desc, data_bytes, expect', [
+        (packets.DataMessages.IMU.msg_ind, 0x0e, 0x04,
+         b'\x3e\x7a\x63\xa0xbb\x8e\x3b\x29\x7f\xe5\xbf7f',
+         ['Accel g', 'Accel g', 'Accel g']),
+        (packets.DataMessages.GPS.msg_ind, 0x08, 0x0b,
+         b'\x00\x01\x00\x02\x00\x03', ['n/a', 'count', 'n/a', 'n/a']),
+         (packets.DataMessages.EKF.msg_ind, 0x10, 0x30,
+          14*b'\x00', ['m', 'm', 'm', 'n/a'])]
+)
+def test_get_units_for_data_message(msg_type, field_len, field_desc, data_bytes,
+                                    expect):
+    field_data = packets.MipsField(field_len, field_desc,
+                                       data_bytes=data_bytes)
+    units = packets.ReplyFormats.get_field_units(msg_type, field_data)
+    assert units == expect
+
+def test_decode_ekf_status_init_mode():
+    status = packets.ReplyFormats.FilterState(1, 1, 0x3000)
+    result = packets.ReplyFormats.decode_ekf_status(status)
+    assert len(result) == 2
+
+def test_decode_ekf_status_run_mode():
+    status = packets.ReplyFormats.FilterState(2, 1, 0x2ffb)
+    result = packets.ReplyFormats.decode_ekf_status(status)
+    assert len(result) == 12
+
+@pytest.mark.parametrize(
+    'payload_bytes, field_list', [
+        # Device reset example - single field case.
+        (b'\x04\xf1\x7e\x00', [
+            packets.MipsField(0x04, 0xf1, [0x7e, 0x00])
+        ]),
+        # Save IMU/estimation format - multiple field case.
+        (b'\x04\x08\x03\x00\x04\x0a\x03\x00',
+         [packets.MipsField(0x04, 0x08, [0x03, 0x00]),
+          packets.MipsField(0x04, 0x0a, [0x03, 0x00])]),
+        # Initialize attitude - note data must be passed in one byte at
+        # a time, even though the 3 values are each 4 bytes.
+        (b'\x0e\x02\xba\xe3\xed\x9b\x3c\x7d\x6d\xdf\xbf\x85\x5c\xf5', [
+            packets.MipsField(0x0e, 0x02, [0xba, 0xe3, 0xed, 0x9b,
+                                               0x3c, 0x7d, 0x6d, 0xdf,
+                                               0xbf, 0x85, 0x5c, 0xf5])]),
+        ]
+)
+def test_split_fields_from_payload_data(payload_bytes, field_list):
+    result = packets.split_payload_to_fields(payload_bytes)
+    assert result == field_list
+
+@pytest.mark.parametrize(
+    'packet, expected_checksum', [
+        (b'\x75\x65\x01\x02\x02\x01', b'\xe0\xc6'),  # Ping example.
+        (b'\x75\x65\x01\x04\x04\xf1\x01\x00', b'\xd5\x6a'),  # Ping response.
+        (b'\x75\x65\x0c\x0a\x0a\x01\x00\x02\x04\x00\x00\x05\x00\x00',
+         b'\x06\x27')  # Poll IMU.
+    ]
+)
+def test_checksum_calculation(packet, expected_checksum):
+    check_sum = packets.fletcher_checksum(packet)
+    assert check_sum == expected_checksum
+
+def test_process_mips_packet():
+    imu_fields = [
+        packets.MipsField(
+        0x0e, 0x04, data_bytes=b'?\x80\x00\x00@\x00\x00\x00@@\x00\x00'),
+        packets.MipsField(0x06, 0x17, data_bytes=b'?\x80\x00\x00'),
+        packets.MipsField(
+        0x12, 0x0a, data_bytes=b'?\x80\x00\x00' + 12*b'\x00')]
+    gps_fields = [packets.MipsField(0x08, 0x0b, data = [0, 1, 0, 2, 0, 3])]
+    imu_desc = packets.DataMessages.IMU.msg_ind
+    gps_desc = packets.DataMessages.GPS.msg_ind
+    packet_list = [packets.MipsPacket(imu_desc, imu_fields),
+               packets.MipsPacket(gps_desc, gps_fields)]
+    result = packets.process_mips_packets(packet_list)
+    assert result == [packets.ReplyFormats.Vector(1.0, 2.0, 3.0),
+                      packets.ReplyFormats.AmbPressure(1.0),
+                      packets.ReplyFormats.Quat(1.0, 0, 0, 0),
+                      packets.ReplyFormats.GPSFix(0, 1, 2, 3)]
+    
+def test_flatten_payload():
+    gps_fields = [
+        packets.MipsField(0x08, 0x0b, data = [0, 1, 0, 2, 0, 3]),
+        packets.MipsField(0x0f, 0x08,
+                              data=[0, 4, 5, 6, 7, 8, 9, 0, 0, 0, 10, 0, 11])]
+    gps_desc = packets.DataMessages.GPS.msg_ind
+    packet = packets.MipsPacket(gps_desc, gps_fields)
+    assert packet.flatten_payload() == [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]
+
+def test_divide_mips_packets():
+    imu_packet = packets.MipsPacket(
+        packets.DataMessages.IMU.msg_ind,
+        [packets.MipsField(0x06, 0x17, data_bytes=b'?\x80\x00\x00')])
+    gps_packet = packets.MipsPacket(
+        packets.DataMessages.GPS.msg_ind,
+        [packets.MipsField(0x08, 0x0b, data = [0, 1, 0, 2, 0, 3])]
+    )
+    ekf_packet = packets.MipsPacket(
+        packets.DataMessages.EKF.msg_ind,
+        [packets.MipsField(0x02, 0xff)]
+    )
+    packet_list = [imu_packet, gps_packet, ekf_packet, gps_packet, imu_packet,
+               imu_packet]
+    imu, gps, ekf = packets.divide_mips_packets(packet_list)
+    assert (len(imu), len(gps), len(ekf)) == (3, 2, 1)

--- a/Microstrain/run_microstrain.py
+++ b/Microstrain/run_microstrain.py
@@ -10,6 +10,7 @@ as an argument if needed.
 """
 import argparse
 import microstrain
+import packets
 import sys
 
 LICENSE_INFO = """
@@ -96,9 +97,9 @@ if __name__ == '__main__':
         print(f'Result: {unit.device_built_in_test()}')
     if args.rates:
         print('Collecting base rates for device.')
-        imu = unit.device_base_rate(microstrain.DataMessages.IMU)
-        gps = unit.device_base_rate(microstrain.DataMessages.GPS)
-        ekf = unit.device_base_rate(microstrain.DataMessages.EKF)
+        imu = unit.device_base_rate(packets.DataMessages.IMU)
+        gps = unit.device_base_rate(packets.DataMessages.GPS)
+        ekf = unit.device_base_rate(packets.DataMessages.EKF)
         print(f'IMU: {imu}, GPS: {gps}, EKF: {ekf} Hz')
     if args.baud_test:
         new_rate = 460800
@@ -124,59 +125,59 @@ if __name__ == '__main__':
         unit.set_msg_fmt(descriptors=[0x04, 0x10], rate_hz = [1.0, 2.0])
         data = unit.collect_data_stream(args.sample_sec)
         print(f'Received {len(data)} samples.')
-        processed_data = microstrain.process_mips_packets(data)
+        processed_data = packets.process_mips_packets(data)
         print(f'Result: {processed_data}')
     if args.stream_reset:
         print(f'Reset message formats.')
-        unit.reset_msg_fmt(microstrain.DataMessages.IMU)
-        unit.reset_msg_fmt(microstrain.DataMessages.GPS)
-        unit.reset_msg_fmt(microstrain.DataMessages.EKF)
+        unit.reset_msg_fmt(packets.DataMessages.IMU)
+        unit.reset_msg_fmt(packets.DataMessages.GPS)
+        unit.reset_msg_fmt(packets.DataMessages.EKF)
     if args.stream_test:
         print(f'Streaming data for {args.sample_sec} seconds.')
-        unit.set_msg_fmt(microstrain.DataMessages.IMU,
+        unit.set_msg_fmt(packets.DataMessages.IMU,
                          [0x04, 0x10], rate_hz = [1.0, 2.0])
-        unit.set_msg_fmt(microstrain.DataMessages.GPS, [0x03], [1.0])
-        unit.set_msg_fmt(microstrain.DataMessages.EKF,
+        unit.set_msg_fmt(packets.DataMessages.GPS, [0x03], [1.0])
+        unit.set_msg_fmt(packets.DataMessages.EKF,
                          [0x10, 0x06, 0x0b], [5.0])
         data = unit.collect_data_stream(args.sample_sec)
         unit.write_stream_data()
         print(f'Results written to file.')
     if args.stream_high_rate:
         print(f'Streaming data for {args.sample_sec} seconds.')
-        unit.set_msg_fmt(microstrain.DataMessages.IMU,
+        unit.set_msg_fmt(packets.DataMessages.IMU,
                          [0x04], rate_hz = [50.])
         data = unit.collect_data_stream(args.sample_sec)
         unit.write_stream_data()
         print(f'Results written to file.')
     if args.gps:
         print(f'Collecting example data from GPS.')
-        unit.set_msg_fmt(microstrain.DataMessages.GPS, [4], [1.0])
-        print(f'Result: {unit.poll_data(microstrain.DataMessages.GPS)}')
+        unit.set_msg_fmt(packets.DataMessages.GPS, [4], [1.0])
+        print(f'Result: {unit.poll_data(packets.DataMessages.GPS)}')
     if args.gps_all:
         print(f'Collecting example data from GPS.')
-        unit.set_msg_fmt(microstrain.DataMessages.GPS,
+        unit.set_msg_fmt(packets.DataMessages.GPS,
                          [3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13], rate_hz = [0.1])
-        print(f'Result: {unit.poll_data(microstrain.DataMessages.GPS)}')
+        print(f'Result: {unit.poll_data(packets.DataMessages.GPS)}')
     if args.ekf:
         print(f'Collecting EKF data.')
-        unit.set_msg_fmt(microstrain.DataMessages.EKF, [0x10], [1.0])
-        data = unit.poll_data(microstrain.DataMessages.EKF)[0]
+        unit.set_msg_fmt(packets.DataMessages.EKF, [0x10], [1.0])
+        data = unit.poll_data(packets.DataMessages.EKF)[0]
         print(f'{data}')
-        data_messages = microstrain.ReplyFormats.decode_ekf_status(data)
+        data_messages = packets.ReplyFormats.decode_ekf_status(data)
         print(f'Result: {data_messages}')
     if args.ekf_euler_init:
         print(f'Initialize EKF with Euler angles.')
         unit.ekf_euler_init()
     if args.ekf_all:
         print(f'Collecting lots of EKF data.')
-        unit.set_msg_fmt(microstrain.DataMessages.EKF,
+        unit.set_msg_fmt(packets.DataMessages.EKF,
                          [16, 17, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11,
                           12, 13, 14, 15, 18, 19, 20, 21, 22, 23, 24], [1.0])
-        data = unit.poll_data(microstrain.DataMessages.EKF)
+        data = unit.poll_data(packets.DataMessages.EKF)
         print(f'{data}')            
     if args.gyro_bias:
         print(f'Sampling gyro bias for device for {args.sample_sec} seconds.')
-        bias = unit.capture_gyro_bias(args.sample_sec)
+        bias = unit.capture_gyro_bias(int(args.sample_sec * 1e3))
         print(bias)
 
     if args.raw:


### PR DESCRIPTION
Split the packet definition portion of the microstrain library off into a separate packets one. That makes it easier to separate the hardware interaction in the microstrain library from the packet creation and process general library.