### PR TITLE
Update microstrain library to decode packets easier

### DIFF
--- a/Microstrain/packets_test.py
+++ b/Microstrain/packets_test.py
@@ -49,13 +49,23 @@ def test_get_units_for_data_message(msg_type, field_len, field_desc, data_bytes,
 
 def test_decode_ekf_status_init_mode():
     status = packets.ReplyFormats.FilterState(1, 1, 0x3000)
-    result = packets.ReplyFormats.decode_ekf_status(status)
+    result = packets.ReplyFormats.decode(status)
     assert len(result) == 2
 
 def test_decode_ekf_status_run_mode():
     status = packets.ReplyFormats.FilterState(2, 1, 0x2ffb)
-    result = packets.ReplyFormats.decode_ekf_status(status)
+    result = packets.ReplyFormats.decode(status)
     assert len(result) == 12
+
+def test_decode_gps_fix_info():
+    status = packets.ReplyFormats.GPSFix(0, 7, 0, 7)
+    result = packets.ReplyFormats.decode(status)
+    assert len(result) == 3
+
+def test_decode_gps_hw_status():
+    status = packets.ReplyFormats.GpsHwStatus(1, 4, 1, 7)
+    result = packets.ReplyFormats.decode(status)
+    assert len(result) == 7
 
 @pytest.mark.parametrize(
     'payload_bytes, field_list', [

--- a/Microstrain/run_microstrain.py
+++ b/Microstrain/run_microstrain.py
@@ -163,7 +163,7 @@ if __name__ == '__main__':
         unit.set_msg_fmt(packets.DataMessages.EKF, [0x10], [1.0])
         data = unit.poll_data(packets.DataMessages.EKF)[0]
         print(f'{data}')
-        data_messages = packets.ReplyFormats.decode_ekf_status(data)
+        data_messages = packets.ReplyFormats.decode(data)
         print(f'Result: {data_messages}')
     if args.ekf_euler_init:
         print(f'Initialize EKF with Euler angles.')


### PR DESCRIPTION
As a prep to doing field work with the unit, add capability to more easily translate the messages from the microstrain device. The decoders provide the bit interpretation for the messages from the IMU for messages needed to make sure the HW is ready. Also adds unit tests.