### PR TITLE
Create command to advance screen on PowerCheck+

### DIFF
--- a/PowerCheck/power_check_test.py
+++ b/PowerCheck/power_check_test.py
@@ -120,6 +120,12 @@ def test_set_config_makes_correct_packet_multi_settings(mocker):
     assert mock_packet.call_args_list[0] == mock.call(0xa6, expected_payload)
  
 @pytest.mark.byte_tests
+def test_set_screen_sends_proper_message():
+    unit = power_check.PowerCheck()
+    unit.set_screen(power_check.Screens.AMPS)
+    unit._ser.write.assert_called_with(b'\x80\x03\xad\x01\xb1')
+
+@pytest.mark.byte_tests
 def test_clear_log_sends_proper_message():
     unit = power_check.PowerCheck()
     unit.clear_log_data()


### PR DESCRIPTION
Adds a new command for 1.28 version of firmware to set the screen along with unit test case.